### PR TITLE
Add ascProvider and logging to notarization

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -19,11 +19,13 @@ exports.default = async function notarizing(context) {
     const appName = context.packager.appInfo.productFilename;
 
     try {
+        console.log('  • notarizing');
         return notarize({
             appBundleId: 'com.Concordium.Software.DesktopWallet',
             appPath: `${appOutDir}/${appName}.app`,
             appleId: process.env.APPLEID,
             appleIdPassword: process.env.APPLEIDPASS,
+            ascProvider: 'K762RM4LQ3',
         });
     } catch (e) {
         return e;


### PR DESCRIPTION
## Purpose
When doing notarization on macOS on a computer with multiple available providers the build fails. This change ensures that it selects the correct input to use.

## Changes
Setting the `ascProvider` and added logging when notarization starts.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.