### PR TITLE
override window open handler

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -119,6 +119,13 @@ const createWindow = async () => {
                   },
     });
 
+    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+        const urlPath = url.split('#')[1];
+        mainWindow?.webContents.send(ipcRendererCommands.openRoute, urlPath);
+
+        return { action: 'deny' };
+    });
+
     if (process.env.NODE_ENV === 'production') {
         mainWindow.loadURL(`file://${__dirname}/app.html`);
     } else {


### PR DESCRIPTION
## Purpose

Disables opening internal links in new application windows, and instead simply routes them back into the main application window.

## Changes

- Overridden `windowOpenHandler` on mainwindow.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

Closes #10 
