### PR TITLE
Failed identities now display sessionId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Added an option to add an address book entry while creating a transfer transaction.
 -   Added an introductory screen to set up a node connection for first time users.
 -   It is now possible to remove a failed identity.
+-   Added reference (sessionId) on failed identities, for support.
 
 ### Changed
 

--- a/app/components/IdentityCard/FailedIdentityDetails.tsx
+++ b/app/components/IdentityCard/FailedIdentityDetails.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Identity } from '~/utils/types';
+import SidedRow from '~/components/SidedRow';
+import CopyButton from '~/components/CopyButton';
+import { getSessionId } from '~/utils/identityHelpers';
+
+import styles from './IdentityCard.module.scss';
+
+interface FailedIdentityDetailsProps {
+    identity: Identity;
+}
+
+export default function FailedIdentityDetails({
+    identity,
+}: FailedIdentityDetailsProps) {
+    const sessionId = getSessionId(identity);
+
+    return (
+        <div className={styles.details}>
+            <SidedRow
+                className={styles.detailsRow}
+                left={`SessionId: ${sessionId.substring(0, 8)}...`}
+                right={<CopyButton value={sessionId} />}
+            />
+        </div>
+    );
+}

--- a/app/components/IdentityCard/FailedIdentityDetails.tsx
+++ b/app/components/IdentityCard/FailedIdentityDetails.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import clsx from 'clsx';
 import { Identity } from '~/utils/types';
 import SidedRow from '~/components/SidedRow';
 import CopyButton from '~/components/CopyButton';
+import ExternalLink from '~/components/ExternalLink';
 import { getSessionId } from '~/utils/identityHelpers';
 
 import styles from './IdentityCard.module.scss';
@@ -14,12 +16,22 @@ export default function FailedIdentityDetails({
     identity,
 }: FailedIdentityDetailsProps) {
     const sessionId = getSessionId(identity);
+    const mail = 'concordium-idiss@notabene.id';
+    const subject = `Reference: ${sessionId}`;
 
     return (
         <div className={styles.details}>
+            <p>
+                Contact{' '}
+                <ExternalLink href={`mailto:${mail}?subject=${subject}`}>
+                    {mail}
+                </ExternalLink>{' '}
+                for support.
+            </p>
+            <p>Please provide the reference, when doing so.</p>
             <SidedRow
-                className={styles.detailsRow}
-                left={`SessionId: ${sessionId.substring(0, 8)}...`}
+                className={clsx('body2', styles.detailsRow)}
+                left={`Reference: ${sessionId.substring(0, 8)}...`}
                 right={<CopyButton value={sessionId} />}
             />
         </div>

--- a/app/components/IdentityCard/IdentityCard.tsx
+++ b/app/components/IdentityCard/IdentityCard.tsx
@@ -26,6 +26,7 @@ import Button from '~/cross-app-components/Button';
 import { useUpdateEffect } from '~/utils/hooks';
 import { editIdentityName } from '~/features/IdentitySlice';
 import DeleteIdentity from './DeleteIdentity';
+import FailedIdentityDetails from './FailedIdentityDetails';
 
 import styles from './IdentityCard.module.scss';
 
@@ -199,6 +200,10 @@ function IdentityListElement({
                         ))}
                 </div>
             )}
+            {showAttributes &&
+                identity.status === IdentityStatus.RejectedAndWarned && (
+                    <FailedIdentityDetails identity={identity} />
+                )}
         </Card>
     );
 }

--- a/app/preload/crypto.ts
+++ b/app/preload/crypto.ts
@@ -120,7 +120,7 @@ export function decrypt(
     return data;
 }
 
-function hashSha256(data: (Buffer | Uint8Array)[]) {
+function hashSha256(data: (string | Buffer | Uint8Array)[]) {
     const hash = crypto.createHash('sha256');
     data.forEach((input) => hash.update(input));
     return hash.digest();

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -75,7 +75,7 @@ export type DecryptionResult = DecryptionData | DecryptionError;
 export type CryptoMethods = {
     encrypt: (data: string, password: string) => EncryptedData;
     decrypt: (data: EncryptedData, password: string) => DecryptionResult;
-    sha256: (data: (Buffer | Uint8Array)[]) => Buffer;
+    sha256: (data: (string | Buffer | Uint8Array)[]) => Buffer;
 };
 
 export type GetTransactionsResult = {

--- a/app/utils/identityHelpers.ts
+++ b/app/utils/identityHelpers.ts
@@ -1,5 +1,10 @@
 import { formatDate } from './timeHelpers';
-import { ChosenAttributes, AttributeKey, AttributeKeyName } from './types';
+import {
+    Identity,
+    ChosenAttributes,
+    AttributeKey,
+    AttributeKeyName,
+} from './types';
 
 export const IDENTITY_NAME_MAX_LENGTH = 25;
 
@@ -87,4 +92,9 @@ export function compareAttributes(
     AttributeTag2: AttributeKeyName
 ) {
     return AttributeKey[AttributeTag1] - AttributeKey[AttributeTag2];
+}
+
+export function getSessionId(identity: Identity) {
+    const hash = window.cryptoMethods.sha256([identity.codeUri]);
+    return Buffer.from(hash).toString('hex');
 }


### PR DESCRIPTION
## Purpose

Display sessionId on failed identities, to help support cases.

## Changes

Now displays reference (sessionId) and support email on failed identity.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

