### PR TITLE
fix incomplete printing when account names contains #

### DIFF
--- a/app/utils/printContent.ts
+++ b/app/utils/printContent.ts
@@ -9,7 +9,7 @@ export default async function printContent(target: HTMLIFrameElement) {
 
     try {
         error = await window.printElement(
-            encodeURI(windowToPrint.document.body.outerHTML)
+            encodeURIComponent(windowToPrint.document.body.outerHTML)
         );
     } catch (e) {
         throw new Error(`Failed to print due to: ${e.message}.`);


### PR DESCRIPTION
## Purpose

Fix error causing incomplete print outs, when sender/receiver account names contains a #.

## Changes

Change print to use encodeURIComponent instead of encodeURI (because encodeURI does not encode #)

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
