### PR TITLE
Add message in PickAccount, if the list is empty

### DIFF
--- a/app/components/PickAccount.tsx
+++ b/app/components/PickAccount.tsx
@@ -23,6 +23,7 @@ interface Props {
         account: Account,
         info?: AccountInfo
     ) => ReactNode | undefined;
+    messageWhenEmpty: string;
 }
 
 /**
@@ -34,6 +35,7 @@ export default function PickAccount({
     filter = () => true,
     isDisabled,
     onAccountClicked = noOp,
+    messageWhenEmpty,
 }: Props): JSX.Element {
     const dispatch = useDispatch();
     const accounts = useSelector(accountsSelector);
@@ -63,6 +65,10 @@ export default function PickAccount({
             );
         }
     }, [accounts, dispatch, loaded]);
+
+    if (filtered.length === 0) {
+        return <h2>{messageWhenEmpty}</h2>;
+    }
 
     return (
         <>

--- a/app/pages/Accounts/AccountReport/AccountReport.tsx
+++ b/app/pages/Accounts/AccountReport/AccountReport.tsx
@@ -288,6 +288,7 @@ export default function AccountReport({ location }: Props) {
                                             filter={(account: Account) =>
                                                 !accounts.includes(account)
                                             }
+                                            messageWhenEmpty="All accounts have already been added"
                                         />
                                     </div>
                                 )}

--- a/app/pages/multisig/AccountTransactions/AddBaker.tsx
+++ b/app/pages/multisig/AccountTransactions/AddBaker.tsx
@@ -244,6 +244,7 @@ function AddBakerPage({ exchangeRate, blockSummary }: PageProps) {
                                                 )
                                             )
                                         }
+                                        messageWhenEmpty="There are no accounts that can become bakers"
                                     />
                                 </div>
                             </div>

--- a/app/pages/multisig/AccountTransactions/CreateTransferProposal/CreateTransferProposal.tsx
+++ b/app/pages/multisig/AccountTransactions/CreateTransferProposal/CreateTransferProposal.tsx
@@ -355,6 +355,7 @@ function CreateTransferProposal({
                                         chosenAccount={account}
                                         filter={isMultiSig}
                                         onAccountClicked={continueAction}
+                                        messageWhenEmpty="There are no accounts that require multiple signatures"
                                     />
                                 </div>
                             </Route>

--- a/app/pages/multisig/AccountTransactions/RemoveBaker.tsx
+++ b/app/pages/multisig/AccountTransactions/RemoveBaker.tsx
@@ -152,6 +152,7 @@ function RemoveBakerPage({ exchangeRate }: PageProps) {
                                                 </>
                                             ) : undefined
                                         }
+                                        messageWhenEmpty="There are no baker accounts "
                                     />
                                 </div>
                             </div>

--- a/app/pages/multisig/AccountTransactions/UpdateAccountCredentials/UpdateCredentialsPage.tsx
+++ b/app/pages/multisig/AccountTransactions/UpdateAccountCredentials/UpdateCredentialsPage.tsx
@@ -595,6 +595,7 @@ function UpdateCredentialPage({ exchangeRate }: Props): JSX.Element {
                                             !hasEncryptedBalance(acc)
                                         }
                                         onAccountClicked={onContinue}
+                                        messageWhenEmpty="There are no accounts, which can update its credentials"
                                     />
                                 )}
                             />

--- a/app/pages/multisig/AccountTransactions/UpdateBakerKeys.tsx
+++ b/app/pages/multisig/AccountTransactions/UpdateBakerKeys.tsx
@@ -199,6 +199,7 @@ function UpdateBakerKeysPage({ exchangeRate }: PageProps) {
                                         filter={(_, info) =>
                                             info?.accountBaker !== undefined
                                         }
+                                        messageWhenEmpty="There are no baker accounts "
                                         onAccountClicked={() => {
                                             dispatch(
                                                 push(

--- a/app/pages/multisig/AccountTransactions/UpdateBakerRestakeEarnings.tsx
+++ b/app/pages/multisig/AccountTransactions/UpdateBakerRestakeEarnings.tsx
@@ -134,6 +134,7 @@ function UpdateBakerRestakeEarningsPage({ exchangeRate }: PageProps) {
                                         filter={(_, info) =>
                                             info?.accountBaker !== undefined
                                         }
+                                        messageWhenEmpty="There are no baker accounts "
                                         onAccountClicked={() => {
                                             dispatch(
                                                 push(

--- a/app/pages/multisig/AccountTransactions/UpdateBakerStake.tsx
+++ b/app/pages/multisig/AccountTransactions/UpdateBakerStake.tsx
@@ -149,6 +149,7 @@ function UpdateBakerStakePage({ exchangeRate, blockSummary }: PageProps) {
                                         filter={(_, info) =>
                                             info?.accountBaker !== undefined
                                         }
+                                        messageWhenEmpty="There are no baker accounts "
                                         onAccountClicked={() => {
                                             dispatch(
                                                 push(


### PR DESCRIPTION
## Purpose

Fixes #32.

## Changes

Added MessageWhenEmpty Property to PickAccount, which is displayed, when there are no unfiltered accounts.
The Displayed message depends on the context that PickAccount is in.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

