### PR TITLE
Fix AccountCard info overlay in production

### DIFF
--- a/app/components/AccountCard/AccountCard.module.scss
+++ b/app/components/AccountCard/AccountCard.module.scss
@@ -108,7 +108,7 @@ $border-radius: 10px;
     width: calc(100% - 2px);
     border-radius: $border-radius;
     background: $color-white;
-    opacity: 95%;
+    opacity: 0.95;
 }
 
 .infoText {


### PR DESCRIPTION
## Purpose

Fix the account card info overlay not appearing in production build.

## Changes

Change opacity to use decimals instead of percentages.

