### PR TITLE
Hide pending accounts in multisig flow

### DIFF
--- a/app/components/PickAccount.tsx
+++ b/app/components/PickAccount.tsx
@@ -4,7 +4,7 @@ import { push } from 'connected-react-router';
 import { Account, AccountInfo } from '~/utils/types';
 import AccountCard from '~/components/AccountCard';
 import {
-    accountsSelector,
+    confirmedAccountsSelector,
     accountsInfoSelector,
     loadAccountInfos,
 } from '~/features/AccountSlice';
@@ -38,7 +38,7 @@ export default function PickAccount({
     messageWhenEmpty,
 }: Props): JSX.Element {
     const dispatch = useDispatch();
-    const accounts = useSelector(accountsSelector);
+    const accounts = useSelector(confirmedAccountsSelector);
     const accountsInfo = useSelector(accountsInfoSelector);
     const [chosenIndex, setChosenIndex] = useState<number | undefined>();
     const [loaded, setLoaded] = useState(false);

--- a/app/features/AccountSlice.ts
+++ b/app/features/AccountSlice.ts
@@ -95,6 +95,11 @@ export const accountsOfIdentitySelector = (identity: Identity) => (
         (account) => account.identityId === identity.id
     );
 
+export const confirmedAccountsSelector = (state: RootState) =>
+    state.accounts.accounts.filter(
+        (account) => account.status === AccountStatus.Confirmed
+    );
+
 export const initialAccountNameSelector = (identityId: number) => (
     state: RootState
 ) =>

--- a/app/pages/Accounts/AccountPageHeader.tsx
+++ b/app/pages/Accounts/AccountPageHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import ShieldImage from '@resources/svg/shield.svg';
 import {
-    accountsSelector,
+    confirmedAccountsSelector,
     accountsInfoSelector,
 } from '~/features/AccountSlice';
 import { Account, AccountInfo } from '~/utils/types';
@@ -40,7 +40,7 @@ function isAllDecrypted(accounts: Account[]) {
 }
 
 export default function AccountPageHeader() {
-    const accounts = useSelector(accountsSelector);
+    const accounts = useSelector(confirmedAccountsSelector);
     const accountInfoMap = useSelector(accountsInfoSelector);
     const accountsInfo = Object.values(accountInfoMap);
 

--- a/app/pages/multisig/AccountTransactions/CreateTransferProposal/CreateTransferProposal.tsx
+++ b/app/pages/multisig/AccountTransactions/CreateTransferProposal/CreateTransferProposal.tsx
@@ -31,7 +31,10 @@ import LoadingComponent from '../LoadingComponent';
 import InputTimestamp from '~/components/Form/InputTimestamp';
 import PickRecipient from '~/components/Transfers/PickRecipient';
 import { useTransactionExpiryState } from '~/utils/dataHooks';
-import { accountsSelector, accountInfoSelector } from '~/features/AccountSlice';
+import {
+    confirmedAccountsSelector,
+    accountInfoSelector,
+} from '~/features/AccountSlice';
 import { amountAtDisposal, validateMemo } from '~/utils/transactionHelpers';
 import { collapseFraction } from '~/utils/basicHelpers';
 import { toMicroUnits, displayAsGTU } from '~/utils/gtu';
@@ -84,7 +87,7 @@ function CreateTransferProposal({
     const allowMemo = useAsyncMemo(nodeSupportsMemo);
 
     const { pathname, state } = useLocation<State>();
-    const accounts = useSelector(accountsSelector);
+    const accounts = useSelector(confirmedAccountsSelector);
     const location = pathname.replace(`${transactionKind}`, ':transactionKind');
 
     const handler = findAccountTransactionHandler(transactionKind);


### PR DESCRIPTION
## Purpose

Don't show pending accounts in multisig flow.
Closes #50.

## Changes

Added `confirmedAccountsSelector`, which only returns confirmed accounts.
Use this new selector in multisig flow, which will cause pending and rejected accounts to not be in the list of accounts to choose.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
