### PR TITLE
Account recovery stuck in waiting

### DIFF
--- a/app/components/ChoiceModal.tsx
+++ b/app/components/ChoiceModal.tsx
@@ -34,7 +34,11 @@ export default function ChoiceModal({
     return (
         <Modal disableClose={disableClose} open={open}>
             <h3>{title}</h3>
-            <p>{description}</p>
+            {typeof description === 'string' ? (
+                <p>{description}</p>
+            ) : (
+                <div>{description}</div>
+            )}
             <div className="flex justifySpaceBetween mT30">
                 {actions.map(({ label, location, onPicked, inverted }, i) => (
                     <Button

--- a/app/pages/Recovery/PerformRecovery.tsx
+++ b/app/pages/Recovery/PerformRecovery.tsx
@@ -118,6 +118,7 @@ export default function PerformRecovery({
             setError('Current Blockhash has not been loaded yet');
             return;
         }
+        controller.start();
 
         const walletId = await pairWallet(ledger, dispatch);
 
@@ -181,6 +182,7 @@ export default function PerformRecovery({
             }
             setEmptyIndices((n) => n + 1);
         }
+        controller.finish();
     }
 
     const description = useMemo(
@@ -216,6 +218,7 @@ export default function PerformRecovery({
                 onClick={() => dispatch(push(routes.IDENTITIES))}
             />
             <ChoiceModal
+                disableClose
                 description={description}
                 actions={[
                     { label: 'Look for more' },

--- a/app/pages/Recovery/PerformRecovery.tsx
+++ b/app/pages/Recovery/PerformRecovery.tsx
@@ -87,12 +87,15 @@ export default function PerformRecovery({
     useEffect(() => setStatus(Status.Initial), []);
 
     function promptStop(emptyCount: number) {
-        return new Promise((resolve) => {
+        return new Promise<boolean>((resolve) => {
             setShowStop({
                 emptyCount,
                 postAction: (location) => {
-                    setShowStop(undefined);
-                    resolve(Boolean(location));
+                    const moved = Boolean(location);
+                    if (!moved) {
+                        setShowStop(undefined);
+                    }
+                    resolve(moved);
                 },
             });
         });
@@ -174,13 +177,16 @@ export default function PerformRecovery({
         if (identity || accounts.length) {
             setEmptyIndices(0);
         } else {
+            let moved = false;
             if (
                 emptyIndices > 0 &&
                 (emptyIndices + 1) % identitySpacesBetweenWarning === 0
             ) {
-                await promptStop(emptyIndices);
+                moved = await promptStop(emptyIndices);
             }
-            setEmptyIndices((n) => n + 1);
+            if (!moved) {
+                setEmptyIndices((n) => n + 1);
+            }
         }
         controller.finish();
     }


### PR DESCRIPTION
## Purpose

Closes #52

## Changes

disableClose on recovery warning modal.
Fix controller, in recovery, not stopping recovery when aborted.
Fix \<p\> descendant of \<p\> error in ChoiceModal.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
