### PR TITLE
Improve cbor memo display

### DIFF
--- a/app/pages/Accounts/TransactionListElement.tsx
+++ b/app/pages/Accounts/TransactionListElement.tsx
@@ -246,14 +246,14 @@ function showMemo(
         return null;
     }
     return (
-        <p
+        <pre
             className={clsx(
                 'body4 m0 mT5 textFaded',
                 showFullMemo || styles.lineClamp
             )}
         >
             {memo}
-        </p>
+        </pre>
     );
 }
 

--- a/app/utils/TransactionConverters.ts
+++ b/app/utils/TransactionConverters.ts
@@ -107,7 +107,12 @@ export function convertIncomingTransaction(
     if (transaction.details.memo) {
         // The memo from the proxy is a "hex-encoded byte array".
         try {
-            memo = decodeCBOR(transaction.details.memo).toString();
+            memo = decodeCBOR(transaction.details.memo);
+            if (typeof memo === 'object') {
+                memo = JSON.stringify(memo);
+            } else {
+                memo = memo.toString();
+            }
         } catch {
             memo = transaction.details.memo;
         }


### PR DESCRIPTION
## Purpose

Fix #47

## Changes

When converting incoming memos, use `JSON.stringify` on objects instead of `.toString()`.
Use `<pre>` tag when displaying memo, so it doesn't ignore white space characters.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
