### PR TITLE
Fix fetching transactions from wallet proxy failing silently

### DIFF
--- a/app/constants/errorMessages.json
+++ b/app/constants/errorMessages.json
@@ -1,5 +1,6 @@
 {
     "alreadyPrinting": "You seem to be printing already, please close your current print dialog before attempting to print again.",
     "missingGlobal": "Missing cryptographic parameters, please connect to a node to load these.",
+    "unableToReachWalletProxy": "Unable to reach the Wallet Proxy.",
     "unableToReachNode": "Unable to reach node."
 }

--- a/app/constants/errorMessages.json
+++ b/app/constants/errorMessages.json
@@ -1,6 +1,6 @@
 {
     "alreadyPrinting": "You seem to be printing already, please close your current print dialog before attempting to print again.",
     "missingGlobal": "Missing cryptographic parameters, please connect to a node to load these.",
-    "unableToReachWalletProxy": "Unable to reach the Wallet Proxy.",
+    "unableToReachWalletProxy": "An error occurred while trying to fetch new transactions from service.",
     "unableToReachNode": "Unable to reach node."
 }

--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -33,6 +33,7 @@ import {
 import AbortController from '~/utils/AbortController';
 import { RejectReason } from '~/utils/node/RejectReasonHelper';
 import { max } from '~/utils/basicHelpers';
+import errorMessages from '~/constants/errorMessages.json';
 
 const updateTransactionInterval = 5000;
 
@@ -228,46 +229,59 @@ export async function updateTransactions(
     account: Account,
     controller: AbortController
 ) {
-    async function updateSubroutine(maxId: bigint) {
-        if (controller.isAborted) {
-            controller.finish();
-            return;
-        }
-        const result = await fetchTransactions(account.address, maxId);
-
-        if (maxId !== result.newMaxId) {
-            await updateMaxTransactionId(
-                dispatch,
-                account.address,
-                result.newMaxId.toString()
-            );
-        }
-
-        if (result.newEncrypted) {
-            await updateAllDecrypted(dispatch, account.address, false);
-        }
-
-        if (controller.isAborted) {
-            controller.finish();
-            return;
-        }
-        if (maxId !== result.newMaxId) {
-            await loadTransactions(account, dispatch);
-            if (!result.isFinished) {
-                setTimeout(
-                    updateSubroutine,
-                    updateTransactionInterval,
-                    result.newMaxId
-                );
+    return new Promise<void>((resolve, reject) => {
+        async function updateSubroutine(maxId: bigint) {
+            if (controller.isAborted) {
+                controller.finish();
+                resolve();
                 return;
             }
-        }
-        controller.finish();
-    }
 
-    updateSubroutine(
-        account.maxTransactionId ? BigInt(account.maxTransactionId) : 0n
-    );
+            let result;
+            try {
+                result = await fetchTransactions(account.address, maxId);
+            } catch (e) {
+                controller.finish();
+                reject(errorMessages.unableToReachWalletProxy);
+                return;
+            }
+
+            if (maxId !== result.newMaxId) {
+                await updateMaxTransactionId(
+                    dispatch,
+                    account.address,
+                    result.newMaxId.toString()
+                );
+            }
+
+            if (result.newEncrypted) {
+                await updateAllDecrypted(dispatch, account.address, false);
+            }
+
+            if (controller.isAborted) {
+                controller.finish();
+                resolve();
+                return;
+            }
+            if (maxId !== result.newMaxId) {
+                await loadTransactions(account, dispatch);
+                if (!result.isFinished) {
+                    setTimeout(
+                        updateSubroutine,
+                        updateTransactionInterval,
+                        result.newMaxId
+                    );
+                    return;
+                }
+            }
+            resolve();
+            controller.finish();
+        }
+
+        updateSubroutine(
+            account.maxTransactionId ? BigInt(account.maxTransactionId) : 0n
+        );
+    });
 }
 
 // Add a pending transaction to storage

--- a/app/pages/Accounts/AccountView.tsx
+++ b/app/pages/Accounts/AccountView.tsx
@@ -23,6 +23,7 @@ import { AccountStatus } from '~/utils/types';
 import AbortController from '~/utils/AbortController';
 import { noOp } from '~/utils/basicHelpers';
 import FailedInitialAccount from './FailedInitialAccount';
+import SimpleErrorModal from '~/components/SimpleErrorModal';
 
 // milliseconds between updates of the accountInfo
 const accountInfoUpdateInterval = 30000;
@@ -36,6 +37,7 @@ export default function AccountView() {
     const account = useSelector(chosenAccountSelector);
     const accountInfo = useSelector(chosenAccountInfoSelector);
     const [controller] = useState(new AbortController());
+    const [error, setError] = useState<string>();
 
     useEffect(() => {
         if (account) {
@@ -64,7 +66,7 @@ export default function AccountView() {
             !controller.isAborted
         ) {
             controller.start();
-            updateTransactions(dispatch, account, controller);
+            updateTransactions(dispatch, account, controller).catch(setError);
             return () => {
                 controller.abort();
             };
@@ -103,6 +105,12 @@ export default function AccountView() {
 
     return (
         <>
+            <SimpleErrorModal
+                show={Boolean(error)}
+                header="Updating Transactions failed"
+                content={error}
+                onClick={() => setError(undefined)}
+            />
             <AccountBalanceView />
             <AccountViewActions account={account} accountInfo={accountInfo} />
             <Switch>


### PR DESCRIPTION
## Purpose

Fix #41 .

## Changes

Reworked updateTransactions to return a promise, that gets resolved/rejected when the updating is done or fails.
AccountView now catches rejections from updateTransactions and displays an error to the user.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.