### PR TITLE
Fix: Encrypted transfer fail if another is pending

### DIFF
--- a/app/components/Transfers/EncryptedTransfer.tsx
+++ b/app/components/Transfers/EncryptedTransfer.tsx
@@ -10,12 +10,12 @@ import {
     Fraction,
 } from '~/utils/types';
 import { toMicroUnits } from '~/utils/gtu';
-import locations from '~/constants/transferLocations.json';
 import { createEncryptedTransferTransaction } from '~/utils/transactionHelpers';
 import ExternalTransfer from '~/components/Transfers/ExternalTransfer';
 import { multiplyFraction } from '~/utils/basicHelpers';
 
-import ensureExchangeRateAndNonce from '~/components/Transfers/ensureExchangeRateAndNonce';
+import ensureExchangeRateAndNonce from './ensureExchangeRateAndNonce';
+import ensureNoPendingShieldedBalance from './ensureNoPendingShieldedBalance';
 
 interface Props {
     account: Account;
@@ -52,9 +52,8 @@ function EncryptedTransfer({ account, exchangeRate, nonce }: Props) {
                     pathname: routes.SUBMITTRANSFER,
                     state: {
                         confirmed: {
-                            pathname: routes.ACCOUNTS_ENCRYPTEDTRANSFER,
+                            pathname: routes.ACCOUNTS_FINAL_PAGE,
                             state: {
-                                initialPage: locations.transferSubmitted,
                                 transaction: stringify(transaction),
                                 recipient,
                             },
@@ -62,7 +61,6 @@ function EncryptedTransfer({ account, exchangeRate, nonce }: Props) {
                         cancelled: {
                             pathname: routes.ACCOUNTS_ENCRYPTEDTRANSFER,
                             state: {
-                                initialPage: locations.pickAmount,
                                 amount,
                                 memo,
                                 recipient,
@@ -90,4 +88,6 @@ function EncryptedTransfer({ account, exchangeRate, nonce }: Props) {
     );
 }
 
-export default ensureExchangeRateAndNonce(EncryptedTransfer);
+export default ensureExchangeRateAndNonce(
+    ensureNoPendingShieldedBalance(EncryptedTransfer)
+);

--- a/app/components/Transfers/ExternalTransfer/ExternalTransfer.tsx
+++ b/app/components/Transfers/ExternalTransfer/ExternalTransfer.tsx
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router-dom';
 import PlusIcon from '@resources/svg/plus.svg';
 import PickRecipient from '../PickRecipient';
 import PickAmount from '../PickAmount';
-import FinalPage from '../FinalPage';
 import { getTransactionKindCost } from '~/utils/transactionCosts';
 import { TransactionKindId, AddressBookEntry, Fraction } from '~/utils/types';
 import locations from '~/constants/transferLocations.json';
@@ -44,7 +43,7 @@ export default function ExternalTransfer({
     const allowMemo = useAsyncMemo(nodeSupportsMemo);
 
     const [subLocation, setSubLocation] = useState<string>(
-        location?.state?.initialPage || locations.pickAmount
+        locations.pickAmount
     );
 
     const [amount, setAmount] = useState<string>(
@@ -73,10 +72,7 @@ export default function ExternalTransfer({
 
     return (
         <TransferView
-            showBack={
-                subLocation === locations.pickRecipient ||
-                subLocation === locations.confirmTransfer
-            }
+            showBack={subLocation === locations.pickRecipient}
             exitOnClick={exitFunction}
             backOnClick={() => setSubLocation(locations.pickAmount)}
         >
@@ -137,9 +133,6 @@ export default function ExternalTransfer({
                         <PlusIcon />
                     </UpsertAddress>
                 </>
-            )}
-            {subLocation === locations.transferSubmitted && (
-                <FinalPage location={location} />
             )}
         </TransferView>
     );

--- a/app/components/Transfers/FinalPage.tsx
+++ b/app/components/Transfers/FinalPage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { LocationDescriptorObject } from 'history';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
+import { useLocation } from 'react-router-dom';
 import { parse } from '~/utils/JSONHelper';
 import routes from '~/constants/routes.json';
 import { displayAsGTU } from '~/utils/gtu';
@@ -8,6 +10,7 @@ import { getScheduledTransferAmount } from '~/utils/transactionHelpers';
 import DisplayEstimatedFee from '~/components/DisplayEstimatedFee';
 import ButtonNavLink from '~/components/ButtonNavLink';
 import DisplayMemo from '~/components/DisplayMemo';
+import TransferView from './TransferView';
 
 import {
     AddressBookEntry,
@@ -27,10 +30,6 @@ interface State {
     transaction: string;
     recipient: AddressBookEntry;
     transactionHash?: string;
-}
-
-interface Props {
-    location: LocationDescriptorObject<State>;
 }
 
 function getSpecificsHandler(transaction: AccountTransaction) {
@@ -103,7 +102,9 @@ function displayRecipient(recipient: AddressBookEntry) {
 /**
  * Displays details of a submitted transaction.
  */
-export default function FinalPage({ location }: Props): JSX.Element {
+export default function FinalPage(): JSX.Element {
+    const dispatch = useDispatch();
+    const location = useLocation<State>();
     if (!location.state) {
         throw new Error('Unexpected missing state.');
     }
@@ -117,7 +118,10 @@ export default function FinalPage({ location }: Props): JSX.Element {
     const handler = getSpecificsHandler(transaction);
 
     return (
-        <>
+        <TransferView
+            showBack={false}
+            exitOnClick={() => dispatch(push(routes.ACCOUNTS))}
+        >
             <h3 className="textCenter mB0">{handler.title}</h3>
             <h1 className="textCenter mT10 mB0">
                 {displayAsGTU(handler.amount)}
@@ -141,6 +145,6 @@ export default function FinalPage({ location }: Props): JSX.Element {
             >
                 Finish
             </ButtonNavLink>
-        </>
+        </TransferView>
     );
 }

--- a/app/components/Transfers/InternalTransfer.tsx
+++ b/app/components/Transfers/InternalTransfer.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { useLocation } from 'react-router-dom';
 import { stringify } from '~/utils/JSONHelper';
 import routes from '~/constants/routes.json';
 import PickAmount from './PickAmount';
-import FinalPage from './FinalPage';
 import {
     Account,
     TransferToEncrypted,
@@ -14,7 +13,6 @@ import {
     Fraction,
 } from '~/utils/types';
 import { toMicroUnits } from '~/utils/gtu';
-import locations from '~/constants/transferLocations.json';
 import { TransferState } from '~/utils/transactionTypes';
 import { getTransactionKindCost } from '~/utils/transactionCosts';
 import TransferView from './TransferView';
@@ -51,10 +49,6 @@ function InternalTransfer<T extends TransferToPublic | TransferToEncrypted>({
         [specific.transactionKind, exchangeRate]
     );
 
-    const [subLocation, setSubLocation] = useState<string>(
-        location?.state?.initialPage || locations.pickAmount
-    );
-
     const toConfirmTransfer = useCallback(
         async (amount: string) => {
             const transaction = await specific.createTransaction(
@@ -70,16 +64,14 @@ function InternalTransfer<T extends TransferToPublic | TransferToEncrypted>({
                     pathname: routes.SUBMITTRANSFER,
                     state: {
                         confirmed: {
-                            pathname: specific.location,
+                            pathname: routes.ACCOUNTS_FINAL_PAGE,
                             state: {
-                                initialPage: locations.transferSubmitted,
                                 transaction: transactionJSON,
                             },
                         },
                         cancelled: {
                             pathname: specific.location,
                             state: {
-                                initialPage: locations.pickAmount,
                                 amount,
                             },
                         },
@@ -94,23 +86,17 @@ function InternalTransfer<T extends TransferToPublic | TransferToEncrypted>({
 
     return (
         <TransferView
-            showBack={subLocation === locations.confirmTransfer}
+            showBack={false}
             exitOnClick={() => dispatch(push(routes.ACCOUNTS))}
-            backOnClick={() => setSubLocation(locations.pickAmount)}
         >
-            {subLocation === locations.pickAmount && (
-                <PickAmount
-                    header={specific.amountHeader}
-                    estimatedFee={estimatedFee}
-                    defaultAmount={location?.state?.amount ?? ''}
-                    toPickRecipient={undefined}
-                    toConfirmTransfer={toConfirmTransfer}
-                    transactionKind={specific.transactionKind}
-                />
-            )}
-            {subLocation === locations.transferSubmitted && (
-                <FinalPage location={location} />
-            )}
+            <PickAmount
+                header={specific.amountHeader}
+                estimatedFee={estimatedFee}
+                defaultAmount={location?.state?.amount ?? ''}
+                toPickRecipient={undefined}
+                toConfirmTransfer={toConfirmTransfer}
+                transactionKind={specific.transactionKind}
+            />
         </TransferView>
     );
 }

--- a/app/components/Transfers/SimpleTransfer.tsx
+++ b/app/components/Transfers/SimpleTransfer.tsx
@@ -11,7 +11,6 @@ import {
     Fraction,
 } from '../../utils/types';
 import { toMicroUnits } from '../../utils/gtu';
-import locations from '../../constants/transferLocations.json';
 import {
     createSimpleTransferTransaction,
     createSimpleTransferWithMemoTransaction,
@@ -69,9 +68,8 @@ function SimpleTransfer({ account, exchangeRate, nonce }: Props) {
                     pathname: routes.SUBMITTRANSFER,
                     state: {
                         confirmed: {
-                            pathname: routes.ACCOUNTS_SIMPLETRANSFER,
+                            pathname: routes.ACCOUNTS_FINAL_PAGE,
                             state: {
-                                initialPage: locations.transferSubmitted,
                                 transaction: stringify(transaction),
                                 recipient,
                             },
@@ -79,7 +77,6 @@ function SimpleTransfer({ account, exchangeRate, nonce }: Props) {
                         cancelled: {
                             pathname: routes.ACCOUNTS_SIMPLETRANSFER,
                             state: {
-                                initialPage: locations.pickAmount,
                                 amount,
                                 memo,
                                 recipient,

--- a/app/components/Transfers/UnshieldAmount.tsx
+++ b/app/components/Transfers/UnshieldAmount.tsx
@@ -3,6 +3,7 @@ import routes from '~/constants/routes.json';
 import { createUnshieldAmountTransaction } from '~/utils/transactionHelpers';
 import { Account, TransactionKindId } from '~/utils/types';
 import InternalTransfer from './InternalTransfer';
+import ensureNoPendingShieldedBalance from './ensureNoPendingShieldedBalance';
 
 interface Props {
     account: Account;
@@ -11,7 +12,7 @@ interface Props {
 /**
  * Controls the flow of creating a transfer to public.
  */
-export default function UnshieldAmount({ account }: Props) {
+function UnshieldAmount({ account }: Props) {
     const specific = {
         amountHeader: 'Unshield GTU',
         createTransaction: createUnshieldAmountTransaction,
@@ -21,3 +22,5 @@ export default function UnshieldAmount({ account }: Props) {
 
     return <InternalTransfer account={account} specific={specific} />;
 }
+
+export default ensureNoPendingShieldedBalance(UnshieldAmount);

--- a/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
+++ b/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
@@ -16,10 +16,8 @@ export interface WithAccount {
 export default function ensureNoPendingShieldedBalance<
     TProps extends WithAccount
 >(Component: ComponentType<TProps>): ComponentType<TProps> {
-    const EnsureNoPendingShieldedBalanceComponent = ({
-        account,
-        ...props
-    }: TProps) => {
+    const EnsureNoPendingShieldedBalanceComponent = (props: TProps) => {
+        const { account } = props;
         const dispatch = useDispatch();
         const [showError, setShowError] = useState<boolean>(false);
 
@@ -37,7 +35,7 @@ export default function ensureNoPendingShieldedBalance<
                     header="Account has pending transfer impacting shielded balance"
                     onClick={() => dispatch(routerActions.goBack())}
                 />
-                <Component {...props} account={account} />
+                <Component {...props} />
             </>
         );
     };

--- a/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
+++ b/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
@@ -33,6 +33,7 @@ export default function ensureNoPendingShieldedBalance<
                 <SimpleErrorModal
                     show={showError}
                     header="Account has pending transfer impacting shielded balance"
+                    content="Please wait for any pending shield amounts, unshield amounts or shielded transfers to finalize."
                     onClick={() => dispatch(routerActions.goBack())}
                 />
                 <Component {...props} />

--- a/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
+++ b/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
@@ -1,0 +1,45 @@
+import React, { ComponentType, useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { routerActions } from 'connected-react-router';
+import { Account } from '~/utils/types';
+import { hasPendingShieldedBalanceTransfer } from '~/database/TransactionDao';
+import SimpleErrorModal from '~/components/SimpleErrorModal';
+
+export interface WithAccount {
+    account: Account;
+}
+
+/**
+ * Component that injects the next nonce on the given account.
+ * Requires the component to have prop account containing an Account.
+ */
+export default function ensureNoPendingShieldedBalance<
+    TProps extends WithAccount
+>(Component: ComponentType<TProps>): ComponentType<TProps> {
+    const EnsureNoPendingShieldedBalanceComponent = ({
+        account,
+        ...props
+    }: TProps) => {
+        const dispatch = useDispatch();
+        const [showError, setShowError] = useState<boolean>(false);
+
+        useEffect(() => {
+            hasPendingShieldedBalanceTransfer(account.address)
+                .then(setShowError)
+                .catch(() => {});
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [account.address]);
+
+        return (
+            <>
+                <SimpleErrorModal
+                    show={showError}
+                    header="Account has pending transfer impacting shielded balance"
+                    onClick={() => dispatch(routerActions.goBack())}
+                />
+                <Component {...props} account={account} />
+            </>
+        );
+    };
+    return EnsureNoPendingShieldedBalanceComponent;
+}

--- a/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
+++ b/app/components/Transfers/ensureNoPendingShieldedBalance.tsx
@@ -10,7 +10,7 @@ export interface WithAccount {
 }
 
 /**
- * Component that injects the next nonce on the given account.
+ * Component that ensures the account does not have have a pending shielded balance transaction.
  * Requires the component to have prop account containing an Account.
  */
 export default function ensureNoPendingShieldedBalance<

--- a/app/constants/routes.json
+++ b/app/constants/routes.json
@@ -12,6 +12,7 @@
     "ACCOUNTS_UNSHIELDAMOUNT": "/accounts/unshield-amount",
     "ACCOUNTS_SHIELDAMOUNT": "/accounts/shield-amount",
     "ACCOUNTS_ENCRYPTEDTRANSFER": "/accounts/encrypted-transfer",
+    "ACCOUNTS_FINAL_PAGE": "/accounts/final-page",
     "SHOWADDRESS": "/accounts/show-address",
     "SUBMITTRANSFER": "/accounts/submit-transfer",
     "ACCOUNTS_MORE": "/accounts/more",

--- a/app/constants/transferLocations.json
+++ b/app/constants/transferLocations.json
@@ -1,7 +1,5 @@
 {
     "pickAmount": "pick-amount",
     "pickRecipient": "pick-recipient",
-    "confirmTransfer": "confirm-transfer",
-    "transferSubmitted": "transfer-submitted",
     "buildSchedule": "build-schedule"
 }

--- a/app/database/TransactionDao.ts
+++ b/app/database/TransactionDao.ts
@@ -2,6 +2,7 @@ export const {
     getPending: getPendingTransactions,
     hasPending: hasPendingTransactions,
     hasEncryptedTransactions,
+    hasPendingShieldedBalanceTransfer,
     update: updateTransaction,
     insert: insertTransactions,
     getTransactionsForAccount: getTransactionsOfAccount,

--- a/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
+++ b/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+import { Knex } from 'knex';
+import { transactionTable } from '~/constants/databaseNames.json';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable(transactionTable, (table) => {
+        table.index('status');
+        table.index('transactionKind');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable(transactionTable, (table) => {
+        table.dropIndex('status');
+        table.dropIndex('transactionKind');
+    });
+}

--- a/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
+++ b/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
@@ -6,6 +6,7 @@ export async function up(knex: Knex): Promise<void> {
     return knex.schema.alterTable(transactionTable, (table) => {
         table.index('status');
         table.index('transactionKind');
+        table.index('blockTime');
     });
 }
 
@@ -13,5 +14,6 @@ export async function down(knex: Knex): Promise<void> {
     return knex.schema.alterTable(transactionTable, (table) => {
         table.dropIndex('status');
         table.dropIndex('transactionKind');
+        table.dropIndex('blockTime');
     });
 }

--- a/app/pages/Accounts/AccountView.tsx
+++ b/app/pages/Accounts/AccountView.tsx
@@ -12,6 +12,7 @@ import {
 } from '~/features/TransactionSlice';
 import routes from '~/constants/routes.json';
 import MoreActions from './MoreActions';
+import FinalPage from '~/components/Transfers/FinalPage';
 import EncryptedTransfer from '~/components/Transfers/EncryptedTransfer';
 import SimpleTransfer from '~/components/Transfers/SimpleTransfer';
 import ShieldAmount from '~/components/Transfers/ShieldAmount';
@@ -130,6 +131,10 @@ export default function AccountView() {
                 <Route
                     path={routes.ACCOUNTS_UNSHIELDAMOUNT}
                     render={() => <UnshieldAmount account={account} />}
+                />
+                <Route
+                    path={routes.ACCOUNTS_FINAL_PAGE}
+                    component={FinalPage}
                 />
                 <Route
                     path={routes.ACCOUNTS}

--- a/app/pages/Accounts/BuildSchedule/BuildSchedule.tsx
+++ b/app/pages/Accounts/BuildSchedule/BuildSchedule.tsx
@@ -12,7 +12,6 @@ import {
     createScheduledTransferTransaction,
     amountAtDisposal,
 } from '~/utils/transactionHelpers';
-import locations from '~/constants/transferLocations.json';
 import RegularInterval from '~/components/BuildSchedule/BuildRegularInterval';
 import ExplicitSchedule from '~/components/BuildSchedule/BuildExplicitSchedule';
 import { BuildScheduleDefaults } from '~/components/BuildSchedule/util';
@@ -122,13 +121,11 @@ export default function BuildSchedule({ location }: Props) {
                     pathname: routes.SUBMITTRANSFER,
                     state: {
                         confirmed: {
-                            pathname:
-                                routes.ACCOUNTS_MORE_CREATESCHEDULEDTRANSFER,
+                            pathname: routes.ACCOUNTS_FINAL_PAGE,
                             state: {
                                 transaction: transactionJSON,
                                 account,
                                 recipient,
-                                initialPage: locations.transferSubmitted,
                             },
                         },
                         cancelled: {

--- a/app/pages/Accounts/SubmitTransfer/SubmitTransfer.tsx
+++ b/app/pages/Accounts/SubmitTransfer/SubmitTransfer.tsx
@@ -41,12 +41,12 @@ import { buildTransactionAccountSignature } from '~/utils/transactionHelpers';
 import findLocalDeployedCredentialWithWallet from '~/utils/credentialHelper';
 import errorMessages from '~/constants/errorMessages.json';
 import routes from '~/constants/routes.json';
-
-import styles from './SubmitTransfer.module.scss';
 import Card from '~/cross-app-components/Card';
 import PrintButton from '~/components/PrintButton';
 import SimpleErrorModal from '~/components/SimpleErrorModal';
 import findHandler from '~/utils/transactionHandlers/HandlerFinder';
+
+import styles from './SubmitTransfer.module.scss';
 
 interface Location {
     pathname: string;
@@ -69,15 +69,22 @@ async function attachCompletedPayload(
     ledger: ConcordiumLedgerClient,
     global: Global,
     credential: CredentialWithIdentityNumber,
-    accountInfo: AccountInfo
+    accountInfo: AccountInfo,
+    setMessage: (message: string) => void
 ) {
-    if (instanceOfTransferToEncrypted(transaction)) {
+    const getPrfKey = async () => {
+        setMessage('Please accept decrypt on device');
         const prfKeySeed = await ledger.getPrfKeyDecrypt(
             credential.identityNumber
         );
+        setMessage('Please wait');
+        return prfKeySeed.toString('hex');
+    };
+
+    if (instanceOfTransferToEncrypted(transaction)) {
         const data = await makeTransferToEncryptedData(
             transaction.payload.amount,
-            prfKeySeed.toString('hex'),
+            await getPrfKey(),
             global,
             accountInfo.accountEncryptedAmount,
             credential.credentialNumber
@@ -92,12 +99,9 @@ async function attachCompletedPayload(
         return { ...transaction, payload };
     }
     if (instanceOfTransferToPublic(transaction)) {
-        const prfKeySeed = await ledger.getPrfKeyDecrypt(
-            credential.identityNumber
-        );
         const data = await makeTransferToPublicData(
             transaction.payload.transferAmount,
-            prfKeySeed.toString('hex'),
+            await getPrfKey(),
             global,
             accountInfo.accountEncryptedAmount,
             credential.credentialNumber
@@ -116,16 +120,13 @@ async function attachCompletedPayload(
         instanceOfEncryptedTransfer(transaction) ||
         instanceOfEncryptedTransferWithMemo(transaction)
     ) {
-        const prfKeySeed = await ledger.getPrfKeyDecrypt(
-            credential.identityNumber
-        );
         const receiverAccountInfo = await getAccountInfoOfAddress(
             transaction.payload.toAddress
         );
         const data = await makeEncryptedTransferData(
             transaction.payload.plainTransferAmount,
             receiverAccountInfo.accountEncryptionKey,
-            prfKeySeed.toString('hex'),
+            await getPrfKey(),
             global,
             accountInfo.accountEncryptedAmount,
             credential.credentialNumber
@@ -173,7 +174,10 @@ export default function SubmitTransfer({ location }: Props) {
      * then beings monitoring its status before redirecting the user to the
      * final page.
      */
-    async function ledgerSignTransfer(ledger: ConcordiumLedgerClient) {
+    async function ledgerSignTransfer(
+        ledger: ConcordiumLedgerClient,
+        setMessage: (message: string) => void
+    ) {
         const signatureIndex = 0;
 
         if (!global) {
@@ -195,7 +199,8 @@ export default function SubmitTransfer({ location }: Props) {
             ledger,
             global,
             credential,
-            accountInfoMap[account.address]
+            accountInfoMap[account.address],
+            setMessage
         );
 
         const path = getAccountPath({
@@ -203,6 +208,8 @@ export default function SubmitTransfer({ location }: Props) {
             accountIndex: credential.credentialNumber,
             signatureIndex,
         });
+
+        setMessage('Please review and sign transaction on device ');
         const signature: Buffer = await ledger.signTransfer(transaction, path);
         const signatureStructured = buildTransactionAccountSignature(
             credential.credentialIndex,

--- a/app/pages/Accounts/SubmitTransfer/SubmitTransfer.tsx
+++ b/app/pages/Accounts/SubmitTransfer/SubmitTransfer.tsx
@@ -209,7 +209,7 @@ export default function SubmitTransfer({ location }: Props) {
             signatureIndex,
         });
 
-        setMessage('Please review and sign transaction on device ');
+        setMessage('Please review and sign transaction on device');
         const signature: Buffer = await ledger.signTransfer(transaction, path);
         const signatureStructured = buildTransactionAccountSignature(
             credential.credentialIndex,

--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -66,9 +66,10 @@ async function hasEncryptedTransactions(
     const transaction = await (await knex())
         .select()
         .table(transactionTable)
-        .where({
-            transactionKind: TransactionKindString.EncryptedAmountTransfer,
-        })
+        .whereIn('transactionKind', [
+            TransactionKindString.EncryptedAmountTransfer,
+            TransactionKindString.EncryptedAmountTransferWithMemo,
+        ])
         .whereBetween('blockTime', [fromTime, toTime])
         .whereNull('decryptedAmount')
         .where((builder) => {
@@ -76,6 +77,21 @@ async function hasEncryptedTransactions(
                 fromAddress: address,
             });
         })
+        .first();
+    return Boolean(transaction);
+}
+
+async function hasPendingShieldedBalanceTransfer(fromAddress: string) {
+    const transaction = await (await knex())
+        .select()
+        .table(transactionTable)
+        .whereIn('transactionKind', [
+            TransactionKindString.EncryptedAmountTransfer,
+            TransactionKindString.EncryptedAmountTransferWithMemo,
+            TransactionKindString.TransferToEncrypted,
+            TransactionKindString.TransferToPublic,
+        ])
+        .where({ status: TransactionStatus.Pending, fromAddress })
         .first();
     return Boolean(transaction);
 }
@@ -119,6 +135,7 @@ const exposedMethods: TransactionMethods = {
     getPending: getPendingTransactions,
     hasPending: hasPendingTransactions,
     getTransactionsForAccount: getTransactionsOfAccount,
+    hasPendingShieldedBalanceTransfer,
     hasEncryptedTransactions,
     update: updateTransaction,
     insert: insertTransactions,

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -242,6 +242,7 @@ export type TransactionMethods = {
         fromTime: string,
         toTime: string
     ) => Promise<boolean>;
+    hasPendingShieldedBalanceTransfer: (address: string) => Promise<boolean>;
     update: (
         identifier: Record<string, unknown>,
         updatedValues: Partial<TransferTransaction>

--- a/app/utils/transactionTypes.ts
+++ b/app/utils/transactionTypes.ts
@@ -51,7 +51,6 @@ export interface TransferState {
     amount: string;
     transaction: string;
     recipient: AddressBookEntry;
-    initialPage: string;
     memo?: string;
 }
 


### PR DESCRIPTION
## Purpose

Fix #45.

## Changes

When the user tries to create a `shielded transfer` or a `unshield`, they get an error, if they have a pending `shield`/`unshield`/`shielded transfer`.
Now updates ledger component message in `SubmitTransfer.`
Refactored `FinalPage` out of Internal/External Transfer components, to simplify. (and avoid unnecessary calls to node)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

