### PR TITLE
Load batch of new non reward transactions

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -223,12 +223,12 @@ export async function fetchNewestTransactions(
 }
 
 /**
- * Fetches a batch of transactions on the given address, from the given currenMaxId.
+ * Fetches a batch of transactions on the given address, from the given currentMaxId.
  * and saves them to the database.
  * @return An object containing:
- * - newMaxId (the largest id among the loaded)
- * - isFinished whether the transactions were the account's latests, or there are more to fetch.
- * - newEncrypted whether any shielded balance transactions were loaded.
+ * - newMaxId is the largest id among the fetched transactions)
+ * - isFinished is whether the transactions were the account's latests, or there are more to fetch.
+ * - newEncrypted is whether any shielded balance transactions were fetched.
  */
 async function fetchTransactions(address: string, currentMaxId: bigint) {
     const { transactions, full } = await getTransactions(
@@ -255,7 +255,7 @@ async function fetchTransactions(address: string, currentMaxId: bigint) {
 /** Update the transactions from remote source.
  * will fetch transactions in intervals, updating the state each time.
  * stops when it reaches the newest transaction, or it is told to abort by the controller.
- * */
+ */
 export async function updateTransactions(
     dispatch: Dispatch,
     account: Account,

--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 // eslint-disable-next-line import/no-cycle
 import { RootState } from '../store/store';
-import { getTransactions } from '../utils/httpRequests';
+import { getNewestTransactions, getTransactions } from '../utils/httpRequests';
 import { decryptAmounts } from '../utils/rustInterface';
 import {
     getTransactionsOfAccount,
@@ -197,6 +197,22 @@ export async function loadTransactions(
             dispatch(setLoadingTransactions(false));
         }
         dispatch(setTransactions({ transactions }));
+    }
+}
+
+export async function fetchNewestTransactions(
+    dispatch: Dispatch,
+    account: Account
+) {
+    const transactions = await getNewestTransactions(account.address);
+
+    const newTransactions = await insertTransactions(
+        transactions.map((transaction) =>
+            convertIncomingTransaction(transaction, account.address)
+        )
+    );
+    if (newTransactions.some(isShieldedBalanceTransaction)) {
+        await updateAllDecrypted(dispatch, account.address, false);
     }
 }
 

--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -200,6 +200,12 @@ export async function loadTransactions(
     }
 }
 
+/**
+ * Fetches a batch of the newest transactions of the given account,
+ * and saves them to the database, and updates the allDecrypted,
+ * if any shielded balance transaction were loaded.
+ * N.B. does not load reward transactions.
+ */
 export async function fetchNewestTransactions(
     dispatch: Dispatch,
     account: Account
@@ -216,6 +222,14 @@ export async function fetchNewestTransactions(
     }
 }
 
+/**
+ * Fetches a batch of transactions on the given address, from the given currenMaxId.
+ * and saves them to the database.
+ * @return An object containing:
+ * - newMaxId (the largest id among the loaded)
+ * - isFinished whether the transactions were the account's latests, or there are more to fetch.
+ * - newEncrypted whether any shielded balance transactions were loaded.
+ */
 async function fetchTransactions(address: string, currentMaxId: bigint) {
     const { transactions, full } = await getTransactions(
         address,

--- a/app/pages/Accounts/useAccountSync.ts
+++ b/app/pages/Accounts/useAccountSync.ts
@@ -8,6 +8,7 @@ import {
 import {
     updateTransactions,
     loadTransactions,
+    fetchNewestTransactions,
 } from '~/features/TransactionSlice';
 import { noOp } from '~/utils/basicHelpers';
 import { AccountStatus } from '~/utils/types';
@@ -21,6 +22,14 @@ export default function useAccountSync() {
     const account = useSelector(chosenAccountSelector);
     const accountInfo = useSelector(chosenAccountInfoSelector);
     const [controller] = useState(new AbortController());
+
+    useEffect(() => {
+        if (account && account.status === AccountStatus.Confirmed) {
+            fetchNewestTransactions(dispatch, account);
+        }
+        return () => {};
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [account?.address]);
 
     useEffect(() => {
         if (account) {

--- a/app/pages/Accounts/useAccountSync.ts
+++ b/app/pages/Accounts/useAccountSync.ts
@@ -27,7 +27,6 @@ export default function useAccountSync() {
         if (account && account.status === AccountStatus.Confirmed) {
             fetchNewestTransactions(dispatch, account);
         }
-        return () => {};
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [account?.address]);
 

--- a/app/preload/http.ts
+++ b/app/preload/http.ts
@@ -42,6 +42,9 @@ async function httpsGet<T>(
     return JSON.parse(response);
 }
 
+/**
+ * N.B. does not load reward transactions.
+ */
 async function getNewestTransactions(
     address: string
 ): Promise<IncomingTransaction[]> {

--- a/app/preload/http.ts
+++ b/app/preload/http.ts
@@ -10,6 +10,7 @@ import {
     HttpGetResponse,
 } from '~/preload/preloadTypes';
 import ipcCommands from '~/constants/ipcCommands.json';
+import { IncomingTransaction } from '~/utils/types';
 
 function getWalletProxy() {
     const targetNet = getTargetNet();
@@ -41,6 +42,19 @@ async function httpsGet<T>(
     return JSON.parse(response);
 }
 
+async function getNewestTransactions(
+    address: string
+): Promise<IncomingTransaction[]> {
+    const response = await walletProxy.get(
+        `/v1/accTransactions/${address}?limit=${walletProxytransactionLimit}&order=descending&includeRewards=none&includeRawRejectReason`,
+        {
+            transformResponse: (res) => parse(intToString(res, 'id')),
+        }
+    );
+    const { transactions } = response.data;
+    return transactions;
+}
+
 async function getTransactions(
     address: string,
     id: string
@@ -58,6 +72,7 @@ async function getTransactions(
 const exposedMethods: HttpMethods = {
     get: httpsGet,
     getTransactions,
+    getNewestTransactions,
     getIdProviders: async () => {
         const response = await walletProxy.get('/v0/ip_info');
         return response.data;

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -99,6 +99,7 @@ export type HttpMethods = {
         address: string,
         id: string
     ) => Promise<GetTransactionsResult>;
+    getNewestTransactions: (address: string) => Promise<IncomingTransaction[]>;
     getIdProviders: () => Promise<IdentityProvider[]>;
 };
 

--- a/app/utils/httpRequests.ts
+++ b/app/utils/httpRequests.ts
@@ -23,6 +23,10 @@ export async function getTransactions(address: string, id = '0') {
     return window.http.getTransactions(address, id);
 }
 
+export async function getNewestTransactions(address: string) {
+    return window.http.getNewestTransactions(address);
+}
+
 export async function getIdentityProviders() {
     return window.http.getIdProviders();
 }


### PR DESCRIPTION
## Purpose

When a new account is chosen, load a batch of its newest non-reward transactions.
Fix #42.
Blocked by #60.

## Changes

Add function to request newest non-reward transactions from wallet-proxy.
Add effect to useAccountSync, which calls this function.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

