### PR TITLE
Improve transaction insert efficiency

### DIFF
--- a/app/database/TransactionDao.ts
+++ b/app/database/TransactionDao.ts
@@ -4,5 +4,6 @@ export const {
     hasEncryptedTransactions,
     update: updateTransaction,
     insert: insertTransactions,
+    upsertTransactionsAndUpdateMaxId,
     getTransactionsForAccount: getTransactionsOfAccount,
 } = window.database.transaction;

--- a/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
+++ b/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
@@ -7,6 +7,7 @@ export async function up(knex: Knex): Promise<void> {
         table.index('status');
         table.index('transactionKind');
         table.index('blockTime');
+        table.index('transactionHash')
     });
 }
 
@@ -15,5 +16,6 @@ export async function down(knex: Knex): Promise<void> {
         table.dropIndex('status');
         table.dropIndex('transactionKind');
         table.dropIndex('blockTime');
+        table.dropIndex('transactionHash');
     });
 }

--- a/app/features/AccountSlice.ts
+++ b/app/features/AccountSlice.ts
@@ -493,7 +493,6 @@ export async function updateMaxTransactionId(
     maxTransactionId: string
 ) {
     const updatedFields = { maxTransactionId };
-    updateAccount(address, updatedFields);
     return dispatch(updateAccountFields({ address, updatedFields }));
 }
 

--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -229,8 +229,8 @@ async function fetchTransactions(
 }
 
 /**
- * Fetches transactions from the wallet proxy, insert them into the
- * local database and update the state with the updated information.
+ * Fetches transactions from the wallet proxy, inserts them into the
+ * local database and updates the state with the updated information.
  * Stops when the newest transaction has been reached, or if it is told
  * to abort by the controller.
  * */
@@ -269,7 +269,7 @@ export async function updateTransactions(
             );
             await updateMaxTransactionId(
                 dispatch,
-                account.address,
+                address,
                 result.newMaxId.toString()
             );
 
@@ -277,7 +277,7 @@ export async function updateTransactions(
                 isShieldedBalanceTransaction
             );
             if (newEncrypted) {
-                await updateAllDecrypted(dispatch, account.address, false);
+                await updateAllDecrypted(dispatch, address, false);
             }
 
             if (controller.isAborted) {

--- a/app/pages/Accounts/AccountView.tsx
+++ b/app/pages/Accounts/AccountView.tsx
@@ -62,16 +62,11 @@ export default function AccountView() {
         if (
             account &&
             account.status === AccountStatus.Confirmed &&
-            controller.isReady &&
-            !controller.isAborted
+            controller.isReady
         ) {
             controller.start();
             updateTransactions(dispatch, account, controller).catch(setError);
-            return () => {
-                controller.abort();
-            };
         }
-        return () => {};
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         account?.address,
@@ -79,6 +74,11 @@ export default function AccountView() {
         account?.status,
         controller.isAborted,
     ]);
+
+    useEffect(() => {
+        return () => controller.abort();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [account?.address]);
 
     useEffect(() => {
         if (account && account.status === AccountStatus.Confirmed) {

--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -4,7 +4,10 @@ import {
     TransactionStatus,
     TransferTransaction,
 } from '~/utils/types';
-import { transactionTable } from '~/constants/databaseNames.json';
+import {
+    transactionTable,
+    accountsTable,
+} from '~/constants/databaseNames.json';
 import { knex } from '~/database/knex';
 import { chunkArray, partition } from '~/utils/basicHelpers';
 import { GetTransactionsOutput } from '~/database/types';
@@ -37,21 +40,60 @@ async function hasPendingTransactions(fromAddress: string) {
     return Boolean(transaction);
 }
 
+/**
+ * Extracts the most recent transactions for a given account.
+ *
+ * To achieve this we search in the database by block time, which
+ * is extended until we have reached the number of results we are
+ * interested in. If there are not enough results, then less are
+ * returned when we conclude there are no more available transactions.
+ * @param account the account to get transactions for
+ * @param filteredTypes filtering on the transaction kind
+ * @param limit maximum number of transactions to return
+ * @returns a list of the most recent transactions for the account
+ */
 async function getTransactionsOfAccount(
     account: Account,
     filteredTypes: TransactionKindString[] = [],
     limit = 100
 ): Promise<GetTransactionsOutput> {
     const { address } = account;
-    const transactions = await (await knex())
-        .select()
-        .table(transactionTable)
-        .whereNotIn('transactionKind', filteredTypes)
-        .andWhere({ toAddress: address })
-        .orWhere({ fromAddress: address })
-        .orderBy('blockTime', 'desc')
-        .orderBy('id', 'desc')
-        .limit(limit + 1);
+
+    const latestTransaction = await (await knex())(transactionTable)
+        .where({ id: account.maxTransactionId })
+        .first();
+    if (!latestTransaction) {
+        // When there are no transactions in the database, this will be the case.
+        return {
+            transactions: [],
+            more: false,
+        };
+    }
+
+    const maxBlockTime = Number(latestTransaction.blockTime);
+    let expandHours = 1;
+    let fromTime: number;
+    let transactions;
+    do {
+        fromTime = maxBlockTime - 60 * 60 * expandHours;
+
+        const querytransactions = (await knex())<TransferTransaction>(
+            transactionTable
+        )
+            .whereNotIn('transactionKind', filteredTypes)
+            .whereBetween('blockTime', [fromTime, maxBlockTime])
+            .andWhere((builder) =>
+                builder
+                    .where({ toAddress: address })
+                    .orWhere({ fromAddress: address })
+            )
+            .orderBy('blockTime', 'desc')
+            .limit(limit);
+
+        transactions = await querytransactions;
+        expandHours *= 2;
+    } while (transactions.length < limit && fromTime > 0);
+
     return {
         transactions: transactions.slice(0, limit),
         more: transactions.length > limit,
@@ -122,6 +164,59 @@ export async function insertTransactions(
     return additions;
 }
 
+/**
+ * Upserts the provided list of transactions into the database. The maximum
+ * id is used to update the corresponding account.
+ * @param transactions the array of transactions to upsert, coming from the wallet proxy post conversion
+ * @param newMaxId the max of the id's in the array of transactions
+ * @returns the newly added transactions, i.e. the array of transactions that were inserted and not updated
+ */
+export async function upsertTransactionsAndUpdateMaxId(
+    transactions: TransferTransaction[],
+    address: string,
+    newMaxId: bigint
+) {
+    if (transactions.length === 0) {
+        return [];
+    }
+
+    const transactionHashes = transactions
+        .map((t) => t.transactionHash || '')
+        .filter((hash) => hash);
+    const transactionTableKnex = (await knex())(transactionTable);
+
+    const existingTransactions: TransferTransaction[] = await transactionTableKnex
+        .whereIn('transactionHash', transactionHashes)
+        .select();
+
+    const [updates, additions] = partition(transactions, (t) =>
+        existingTransactions.some(
+            (t_) => t.transactionHash === t_.transactionHash
+        )
+    );
+
+    const additionChunks = chunkArray(additions, 50);
+    await (await knex()).transaction(async (trx) => {
+        for (const additionChunk of additionChunks) {
+            await trx.table(transactionTable).insert(additionChunk);
+        }
+
+        for (const updatedTransaction of updates) {
+            await trx
+                .table(transactionTable)
+                .where({ transactionHash: updatedTransaction.transactionHash })
+                .update(updatedTransaction);
+        }
+
+        await trx
+            .table(accountsTable)
+            .where({ address })
+            .update({ maxTransactionId: newMaxId.toString() });
+    });
+
+    return additions;
+}
+
 const exposedMethods: TransactionMethods = {
     getPending: getPendingTransactions,
     hasPending: hasPendingTransactions,
@@ -129,6 +224,7 @@ const exposedMethods: TransactionMethods = {
     hasEncryptedTransactions,
     update: updateTransaction,
     insert: insertTransactions,
+    upsertTransactionsAndUpdateMaxId,
 };
 
 export default exposedMethods;

--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -89,7 +89,14 @@ export async function insertTransactions(
     transactions: Partial<TransferTransaction>[]
 ) {
     const table = (await knex())(transactionTable);
-    const existingTransactions: TransferTransaction[] = await table.select();
+
+    const hashes = transactions
+        .map((t) => t.transactionHash || '')
+        .filter((hash) => hash);
+    const existingTransactions: TransferTransaction[] = await table
+        .whereIn('transactionHash', hashes)
+        .select();
+
     const [updates, additions] = partition(transactions, (t) =>
         existingTransactions.some(
             (t_) => t.transactionHash === t_.transactionHash

--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -88,7 +88,7 @@ async function getTransactionsOfAccount(
                     .orWhere({ fromAddress: address })
             )
             .orderBy('blockTime', 'desc')
-            .limit(limit);
+            .limit(limit + 1);
 
         transactions = await querytransactions;
         expandHours *= 2;

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -249,6 +249,11 @@ export type TransactionMethods = {
     insert: (
         transactions: Partial<TransferTransaction>[]
     ) => Promise<Partial<TransferTransaction>[]>;
+    upsertTransactionsAndUpdateMaxId: (
+        transactions: TransferTransaction[],
+        address: string,
+        newMaxId: bigint
+    ) => Promise<TransferTransaction[]>;
 };
 
 export type WalletMethods = {


### PR DESCRIPTION
## Purpose

Fix #67.

## Changes

Stop loading all transactions when inserting transactions.
Rework AccountView effects so fetching transactions is not interrupted by accountInfo update.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
