### PR TITLE
Allow more than required number of signatures on update instructions

### DIFF
--- a/app/pages/multisig/ProposalView/ProposalView.tsx
+++ b/app/pages/multisig/ProposalView/ProposalView.tsx
@@ -73,6 +73,7 @@ function ProposalView({ proposal }: ProposalViewProps) {
         () => parse(proposal.transaction),
         [proposal]
     );
+    const isAccountTransaction = instanceOfAccountTransaction(transaction);
 
     const signatures = getSignatures(transaction);
 
@@ -149,7 +150,7 @@ function ProposalView({ proposal }: ProposalViewProps) {
             pageTitle={handler.title}
             print={handler.print(transaction, proposal.status, image)}
             stepTitle={`Transaction Proposal - ${handler.type}`}
-            disableBack={instanceOfAccountTransaction(transaction)}
+            disableBack={isAccountTransaction}
             closeRoute={CLOSE_ROUTE}
             delegateScroll
         >
@@ -191,7 +192,7 @@ function ProposalView({ proposal }: ProposalViewProps) {
                             <div>
                                 <h5>
                                     {signatures.length} of {proposal.threshold}{' '}
-                                    signatures.
+                                    required signatures.
                                 </h5>
                                 <div className={styles.signatureCheckboxes}>
                                     <SignatureCheckboxes
@@ -209,7 +210,8 @@ function ProposalView({ proposal }: ProposalViewProps) {
                                     multiple
                                     className={styles.fileInput}
                                     disabled={
-                                        !missingSignatures ||
+                                        (!missingSignatures &&
+                                            isAccountTransaction) ||
                                         currentlyLoadingFile ||
                                         !isOpen
                                     }

--- a/app/pages/multisig/ProposalView/SignatureCheckboxes/SignatureCheckboxes.tsx
+++ b/app/pages/multisig/ProposalView/SignatureCheckboxes/SignatureCheckboxes.tsx
@@ -67,11 +67,12 @@ export default function SignatureCheckboxes({
     threshold,
     signatures,
 }: SignatureCheckboxesProps): JSX.Element {
-    const thresholdArray = new Array(threshold).fill(0);
+    const boxesToShow = Math.max(threshold, signatures.length);
+    const boxesToShowArray = new Array(boxesToShow).fill(0);
 
     return (
         <>
-            {thresholdArray.map((_, i) => (
+            {boxesToShowArray.map((_, i) => (
                 <SignatureCheckbox
                     signature={signatures[i]}
                     name={getCheckboxName(i)}


### PR DESCRIPTION
## Purpose

Allow update instruction proposals to add more than the required number of signatures. 
Fix #74.

## Changes

No longer disable signature input, when required number of signatures have been reached. (on update instructions)
Changed text above signature checkboxes to say "X of Y _required_ signatures".

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
