### PR TITLE
Use multi column indices to improve performance

### DIFF
--- a/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
+++ b/app/database/migrations/20210914132103_add_indices_on_transaction_table.ts
@@ -4,18 +4,22 @@ import { transactionTable } from '~/constants/databaseNames.json';
 
 export async function up(knex: Knex): Promise<void> {
     return knex.schema.alterTable(transactionTable, (table) => {
+        table.index(['toAddress', 'transactionKind', 'blockTime']);
+        table.index(['fromAddress', 'transactionKind', 'blockTime']);
         table.index('status');
-        table.index('transactionKind');
-        table.index('blockTime');
         table.index('transactionHash')
+        table.dropIndex('toAddress');
+        table.dropIndex('fromAddress');
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
     return knex.schema.alterTable(transactionTable, (table) => {
+        table.dropIndex(['toAddress', 'transactionKind', 'blockTime'])
+        table.dropIndex(['fromAddress', 'transactionKind', 'blockTime']);
         table.dropIndex('status');
-        table.dropIndex('transactionKind');
-        table.dropIndex('blockTime');
         table.dropIndex('transactionHash');
+        table.index('toAddress');
+        table.index('fromAddress');
     });
 }


### PR DESCRIPTION
## Purpose
Improve the performance of the latest transactions view on accounts.

## Changes
- Added multi column indices.
- Dropped indices that are now unused to improve space usage.
- Updated queries so that they will use the multi column indices.

Note: The changes were made to an existing migration file, so either downgrade and up again, or start with a new database.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.