### PR TITLE
Fix constraint violations on insert

### DIFF
--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -166,6 +166,11 @@ interface UpdatesAndAdditions<T> {
     updates: T[];
     additions: T[];
 }
+/**
+ * Find which of the given transactions already exists in the database.
+ * @returns updates, which are the transactions that already exist,
+ * and additions, which are those that don't already exist.
+ */
 async function findExistingTransactions<T extends Partial<TransferTransaction>>(
     transactions: T[]
 ): Promise<UpdatesAndAdditions<T>> {

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -273,8 +273,8 @@ export type TransactionMethods = {
         updatedValues: Partial<TransferTransaction>
     ) => Promise<number>;
     insert: (
-        transactions: Partial<TransferTransaction>[]
-    ) => Promise<Partial<TransferTransaction>[]>;
+        transactions: TransferTransaction[]
+    ) => Promise<TransferTransaction[]>;
     getTransaction: (id: string) => Promise<TransferTransaction | undefined>;
     upsertTransactionsAndUpdateMaxId: (
         transactions: TransferTransaction[],


### PR DESCRIPTION
## Purpose

Fix constraint violations, which are happening, when loading transactions (on finalizer accounts).

## Changes

Reworked insertTransactions and upsertTransactionsAndUpdateMaxId:
 - Check for transaction existence using transactionHash _and id_.
 - Changed insertTransactions to update transactionally like upsertTransactionsAndUpdateMaxId.
 - Refactored most of the behaviour into common delegate functions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
