### PR TITLE
Set default account description modal + transaction list element border bug

### DIFF
--- a/app/pages/Accounts/AccountBalanceView/AccountDefaultButton.tsx
+++ b/app/pages/Accounts/AccountBalanceView/AccountDefaultButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import DefaultIcon from '@resources/svg/star-filled.svg';
@@ -24,35 +24,46 @@ export default function AccountDefaultButton({ account, className }: Props) {
     const isDefault = favAccount?.address === address;
     const Icon = isDefault ? DefaultIcon : NotDefaultIcon;
 
-    const setDefault = useCallback(() => {
-        if (favAccount) {
-            setShowPrompt(true);
-        } else {
-            setDefaultAccount(dispatch, address);
-        }
-    }, [favAccount, dispatch, address]);
-
     const close = () => setShowPrompt(false);
+
+    const description: JSX.Element = useMemo(() => {
+        return favAccount ? (
+            <>
+                <b>{favAccount?.name}</b> is currently set as your default
+                account. Do you want to change default account to
+                <br />
+                <br />
+                <b>{name}</b>?
+            </>
+        ) : (
+            <>
+                You are about to set a default account. Setting this means, that
+                this will be the account initially visible when opening the
+                account page.
+                <br />
+                <br />
+                Would you like to set your default account to
+                <br />
+                <br />
+                <b>{name}</b>?
+            </>
+        );
+    }, [favAccount, name]);
 
     return (
         <>
             <ChoiceModal
                 open={showPrompt}
-                title="Set new default account?"
-                description={
-                    <>
-                        <b>{favAccount?.name}</b> is currently set as your
-                        default account. Do you want to change default account
-                        to
-                        <br />
-                        <br />
-                        <b>{name}</b>?
-                    </>
+                title={
+                    favAccount
+                        ? 'Set new default account?'
+                        : 'Set default account?'
                 }
+                description={description}
                 actions={[
                     { label: 'Cancel' },
                     {
-                        label: 'Change default',
+                        label: 'Set default',
                         action: () => setDefaultAccount(dispatch, address),
                     },
                 ]}
@@ -63,7 +74,7 @@ export default function AccountDefaultButton({ account, className }: Props) {
                 className={clsx('inlineFlex', className)}
                 clear
                 disabled={isDefault}
-                onClick={setDefault}
+                onClick={() => setShowPrompt(true)}
             >
                 <Icon width={20} height={20} />
             </Button>

--- a/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
+++ b/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
@@ -29,10 +29,10 @@ import TransactionListHeader, {
 import TransactionListElement, {
     transactionListElementHeight,
 } from './TransactionListElement';
-
-import styles from './TransactionList.module.scss';
 import { TransactionListProps } from './util';
 import useThunkDispatch from '~/store/useThunkDispatch';
+
+import styles from './TransactionList.module.scss';
 
 type HeaderOrTransaction = string | TransferTransaction;
 
@@ -140,7 +140,14 @@ export default function InfiniteTransactionList({
                                     const item = headersAndTransactions[index];
 
                                     if (isHeader(item)) {
-                                        return null; // Handled in "innerElementType"
+                                        return (
+                                            <span
+                                                className={
+                                                    styles.transactionGroupHeaderPlaceholder
+                                                }
+                                                style={style}
+                                            />
+                                        ); // Handled in "innerElementType"
                                     }
 
                                     return (

--- a/app/pages/Accounts/TransactionList/TransactionList.module.scss
+++ b/app/pages/Accounts/TransactionList/TransactionList.module.scss
@@ -58,6 +58,10 @@
     color: $color-success;
 }
 
+.transactionGroupHeaderPlaceholder {
+    opacity: 0;
+}
+
 .transactionGroupHeader {
     composes: cardPadding;
     height: $thick-blue-separator-height;

--- a/app/pages/Accounts/TransactionList/TransactionList.module.scss
+++ b/app/pages/Accounts/TransactionList/TransactionList.module.scss
@@ -7,13 +7,14 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    border-top: 0.5px solid transparent;
 
     &:focus {
         outline: none;
     }
 
-    &:not(:last-child) {
-        border-bottom: 0.5px solid $color-soft-grey;
+    & + & {
+        border-top-color: $color-soft-grey;
     }
 
     &VariableHeight {


### PR DESCRIPTION
## Purpose

Shows a modal first time a default account is set, describing the action at what it implies. Also fixes a small style bug on transaction list elements introduced in #60 

## Changes

- Show prompt modal when setting default account first time
- Hide top border for first transaction list element in list group.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

Closes #91 
