### PR TITLE
ensure word break on memo in print

### DIFF
--- a/app/utils/printUtility.tsx
+++ b/app/utils/printUtility.tsx
@@ -172,7 +172,14 @@ export const displayStatus = (status: MultiSignatureTransactionStatus) => (
 export const displayMemo = (memo: string) => (
     <tr>
         <td>Memo</td>
-        <td>{memo}</td>
+        <td
+            style={{
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+            }}
+        >
+            {memo}
+        </td>
     </tr>
 );
 


### PR DESCRIPTION
## Purpose

Long memos didn't break words properly on print. This ensures that happens

## Changes

- Added word break css to print memo display

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

Closes #95 