### PR TITLE
Fixed bug where baker cooldown end date was incorrect

### DIFF
--- a/app/components/BakerPendingChange/BakerPendingChange.tsx
+++ b/app/components/BakerPendingChange/BakerPendingChange.tsx
@@ -18,7 +18,7 @@ export default function PendingChange({ pending }: PendingChangeProps) {
         epochDate(
             pending.epoch,
             status.epochDuration,
-            new Date(status.genesisTime)
+            new Date(status.currentEraGenesisTime)
         )
     );
 

--- a/app/node/NodeApiTypes.ts
+++ b/app/node/NodeApiTypes.ts
@@ -34,6 +34,8 @@ export interface ConsensusStatus {
     finalizationPeriodEMSD: number;
     genesisBlock: string;
     genesisTime: string;
+    currentEraGenesisBlock: string;
+    currentEraGenesisTime: string;
     lastFinalizedBlock: string;
     lastFinalizedBlockHeight: number;
     lastFinalizedTime: string | null;

--- a/app/utils/dataHooks.ts
+++ b/app/utils/dataHooks.ts
@@ -167,7 +167,7 @@ export function useCalcBakerStakeCooldownUntil() {
     const {
         chainParameters,
     } = lastFinalizedBlockSummary.lastFinalizedBlockSummary.updates;
-    const genesisTime = new Date(consensusStatus.genesisTime);
+    const genesisTime = new Date(consensusStatus.currentEraGenesisTime);
     const currentEpochIndex = getEpochIndexAt(
         now,
         consensusStatus.epochDuration,


### PR DESCRIPTION
## Purpose

Fix #101

## Changes

Calculate baker state cooldown using `currentEraGenesisTime` instead of `genesisTime`.
Added `currentEraGenesisTime` and `currentEraGenesisBlock` to `ConsensusStatus` type.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
