### PR TITLE
Disable account details for non-confirmed accounts

### DIFF
--- a/app/pages/Accounts/AccountListPage/AccountList.tsx
+++ b/app/pages/Accounts/AccountListPage/AccountList.tsx
@@ -9,6 +9,7 @@ import {
 import { setViewingShielded } from '~/features/TransactionSlice';
 import AccountCard from '~/components/AccountCard';
 import CardList from '~/cross-app-components/CardList';
+import { AccountStatus } from '~/utils/types';
 
 /**
  * Displays the List of local accounts, And allows picking the chosen account.
@@ -31,10 +32,14 @@ export default function AccountList() {
                     active={a.address === chosenAccount?.address}
                     account={a}
                     accountInfo={accountsInfo[a.address]}
-                    onClick={(shielded) => {
-                        dispatch(chooseAccount(a.address));
-                        dispatch(setViewingShielded(shielded));
-                    }}
+                    onClick={
+                        a.status === AccountStatus.Pending
+                            ? undefined
+                            : (shielded) => {
+                                  dispatch(chooseAccount(a.address));
+                                  dispatch(setViewingShielded(shielded));
+                              }
+                    }
                 />
             ))}
         </CardList>

--- a/app/pages/Accounts/AccountListPage/AccountList.tsx
+++ b/app/pages/Accounts/AccountListPage/AccountList.tsx
@@ -9,7 +9,11 @@ import {
 import { setViewingShielded } from '~/features/TransactionSlice';
 import AccountCard from '~/components/AccountCard';
 import CardList from '~/cross-app-components/CardList';
-import { AccountStatus } from '~/utils/types';
+import { Account, AccountStatus } from '~/utils/types';
+
+const canSelectAccount = ({ status, isInitial }: Account) =>
+    status !== AccountStatus.Pending &&
+    !(status === AccountStatus.Rejected && isInitial);
 
 /**
  * Displays the List of local accounts, And allows picking the chosen account.
@@ -33,12 +37,12 @@ export default function AccountList() {
                     account={a}
                     accountInfo={accountsInfo[a.address]}
                     onClick={
-                        a.status === AccountStatus.Pending
-                            ? undefined
-                            : (shielded) => {
+                        canSelectAccount(a)
+                            ? (shielded) => {
                                   dispatch(chooseAccount(a.address));
                                   dispatch(setViewingShielded(shielded));
                               }
+                            : undefined
                     }
                 />
             ))}

--- a/app/pages/Accounts/AccountListPage/AccountList.tsx
+++ b/app/pages/Accounts/AccountListPage/AccountList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { push } from 'connected-react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import {
     accountsSelector,
@@ -9,7 +8,6 @@ import {
 } from '~/features/AccountSlice';
 import { setViewingShielded } from '~/features/TransactionSlice';
 import AccountCard from '~/components/AccountCard';
-import routes from '~/constants/routes.json';
 import CardList from '~/cross-app-components/CardList';
 
 /**
@@ -34,7 +32,6 @@ export default function AccountList() {
                     account={a}
                     accountInfo={accountsInfo[a.address]}
                     onClick={(shielded) => {
-                        dispatch(push(routes.ACCOUNTS));
                         dispatch(chooseAccount(a.address));
                         dispatch(setViewingShielded(shielded));
                     }}

--- a/app/pages/Accounts/AccountListPage/AccountList.tsx
+++ b/app/pages/Accounts/AccountListPage/AccountList.tsx
@@ -13,7 +13,7 @@ import { Account, AccountStatus } from '~/utils/types';
 
 const canSelectAccount = ({ status, isInitial }: Account) =>
     status !== AccountStatus.Pending &&
-    !(status === AccountStatus.Rejected && isInitial);
+    (status !== AccountStatus.Rejected || isInitial);
 
 /**
  * Displays the List of local accounts, And allows picking the chosen account.

--- a/app/pages/Accounts/AccountListPage/AccountView.tsx
+++ b/app/pages/Accounts/AccountListPage/AccountView.tsx
@@ -15,6 +15,7 @@ import BasicTransferRoutes from '../BasicTransferRoutes';
 import TransactionsAndAddress from './TransactionsAndAddress/TransactionsAndAddress';
 import DecryptComponent from '../DecryptComponent';
 import withAccountSync from '../withAccountSync';
+import { AccountStatus } from '~/utils/types';
 
 /**
  * Detailed view of the chosen account and its transactions.
@@ -34,17 +35,24 @@ export default withAccountSync(function AccountView() {
             {account.isInitial && accountInfo === undefined && (
                 <FailedInitialAccount account={account} />
             )}
-            <AccountBalanceView />
-            <AccountViewActions account={account} accountInfo={accountInfo} />
-            <BasicTransferRoutes account={account}>
-                <Route path={routes.ACCOUNTS}>
-                    {viewingShielded && !account.allDecrypted ? (
-                        <DecryptComponent account={account} />
-                    ) : (
-                        <TransactionsAndAddress account={account} />
-                    )}
-                </Route>
-            </BasicTransferRoutes>
+            {account.status === AccountStatus.Confirmed && (
+                <>
+                    <AccountBalanceView />
+                    <AccountViewActions
+                        account={account}
+                        accountInfo={accountInfo}
+                    />
+                    <BasicTransferRoutes account={account}>
+                        <Route path={routes.ACCOUNTS}>
+                            {viewingShielded && !account.allDecrypted ? (
+                                <DecryptComponent account={account} />
+                            ) : (
+                                <TransactionsAndAddress account={account} />
+                            )}
+                        </Route>
+                    </BasicTransferRoutes>
+                </>
+            )}
         </>
     );
 });


### PR DESCRIPTION
## Purpose

Functions supposed to be inaccessible for non-confirmed accounts were accessible on the account page. This makes them inaccessible.

Closes #100 

## Changes

- Remove list view details for rejected and pending accounts.
- Made pending and rejected accounts not clickable in list view (except when rejected account is the initial account of an identity - we need this to display a specific error modal)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
