### PR TITLE
Fix minor layout inconsistencies

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -12,7 +12,7 @@ import 'regenerator-runtime/runtime';
 import path from 'path';
 import { app, BrowserView, BrowserWindow } from 'electron';
 import ipcRendererCommands from './constants/ipcRendererCommands.json';
-import { createMenu } from './main/menu';
+import { createMenu, addContextMenu } from './main/menu';
 import initializeIpcHandlers from './main/ipcHandlers';
 import initAutoUpdate from './main/autoUpdate';
 
@@ -142,6 +142,8 @@ const createWindow = async () => {
     });
 
     browserView = new BrowserView();
+
+    addContextMenu(mainWindow);
 
     initializeIpcHandlers(mainWindow, printWindow, browserView);
 

--- a/app/pages/multisig/AccountTransactions/CreateTransferProposal/PickMemo.tsx
+++ b/app/pages/multisig/AccountTransactions/CreateTransferProposal/PickMemo.tsx
@@ -46,6 +46,7 @@ export default function PickMemo({
                 onChange={onMemoChange}
                 onFocus={() => setFocused(true)}
                 placeholder="You can add a memo here"
+                isInvalid={Boolean(error)}
             />
             <MemoWarning
                 open={focused && !shownMemoWarning}


### PR DESCRIPTION
## Purpose

Fix #104

## Changes

Make memo text error-colored on error in multisig flow.
Add context menu that allows cut/copy/paste and spellchecking.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
