### PR TITLE
Disable going back to previous external view

### DIFF
--- a/app/main/ipcHandlers.ts
+++ b/app/main/ipcHandlers.ts
@@ -83,6 +83,7 @@ function createExternalView(
     return new Promise((resolve) => {
         window.setBrowserView(browserView);
         browserView.setBounds(rect);
+        browserView.webContents.clearHistory();
         browserView.webContents
             .loadURL(location)
             .then(() => {


### PR DESCRIPTION
## Purpose

Disable going back to a previous external flow, like another provider's, by pressing back.

## Changes

Clear the BrowserView's history when entering the external issuance view.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.