### PR TITLE
Block browserView opening internal views

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -10,7 +10,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import path from 'path';
-import { app, BrowserView, BrowserWindow } from 'electron';
+import { app, BrowserView, BrowserWindow, shell } from 'electron';
 import ipcRendererCommands from './constants/ipcRendererCommands.json';
 import { createMenu } from './main/menu';
 import initializeIpcHandlers from './main/ipcHandlers';
@@ -142,6 +142,11 @@ const createWindow = async () => {
     });
 
     browserView = new BrowserView();
+
+    browserView.webContents.setWindowOpenHandler(({ url }) => {
+        shell.openExternal(url);
+        return { action: 'deny' };
+    });
 
     initializeIpcHandlers(mainWindow, printWindow, browserView);
 


### PR DESCRIPTION
## Purpose

Currently if the external issuance flow tries to open a new window, it opens a new browser window in the app.

## Changes

Intercept this command and open the website in external browser instead.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

