### PR TITLE
Latest rejected/fulfilled update request sets sync state

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -281,7 +281,6 @@ export const updateTransactions = createAsyncThunk<
         { onFirstLoop, onError },
         { getState, dispatch, signal, requestId }
     ) => {
-        latestUpdateRequestId = requestId;
         const release = await updateLock.acquire();
 
         const state = getState() as RootState;
@@ -422,7 +421,8 @@ const transactionSlice = createSlice({
             }
         });
 
-        builder.addCase(updateTransactions.pending, (state) => {
+        builder.addCase(updateTransactions.pending, (state, { meta }) => {
+            latestUpdateRequestId = meta.requestId;
             state.synchronizing = true;
         });
 
@@ -450,8 +450,10 @@ const transactionSlice = createSlice({
 
         builder.addMatcher(
             isAnyOf(updateTransactions.rejected, updateTransactions.fulfilled),
-            (state) => {
-                state.synchronizing = false;
+            (state, { meta }) => {
+                if (meta.requestId === latestUpdateRequestId) {
+                    state.synchronizing = false;
+                }
             }
         );
 

--- a/app/pages/Accounts/TransactionsHeader/TransactionsHeader.tsx
+++ b/app/pages/Accounts/TransactionsHeader/TransactionsHeader.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function TransactionsHeader({ text }: Props) {
-    const [showSpinner, setShowSpinner] = useState(false);
+    const [showSpinner, setShowSpinner] = useState(true);
     const synchronizing = useSelector(
         (s: RootState) => s.transactions.synchronizing
     );


### PR DESCRIPTION
## Purpose

Transaction sync state was reset when changing view on account page. This fixes that.

## Changes

- Only latest rejected/fulfilled update action sets sync state.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
