### PR TITLE
Update electron-updater dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "electron": "12.0.12",
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.4",
-    "electron-updater": "^4.3.4",
+    "electron-updater": "^4.3.9",
     "framer-motion": "^3.7.0",
     "history": "^4.7.2",
     "html2canvas": "^1.0.0-rc.7",


### PR DESCRIPTION
## Purpose
An issue in electron-updater meant that even if verification of an automatic update failed, then the update was still 
applied on macOS systems. This has been fixed on the newer version of electron-updater.

## Changes
- Bump electron-updater from 4.3.4 to 4.3.9.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.