### PR TITLE
Gtu drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   Added a GTU drop option for testnet and stagenet.
+
 ## 1.2.0
 
 ### Added

--- a/app/pages/Accounts/TransactionList/FiniteTransactionList.tsx
+++ b/app/pages/Accounts/TransactionList/FiniteTransactionList.tsx
@@ -10,6 +10,10 @@ import useTransactionGroups from './useTransactionGroups';
 import { TransactionListProps } from './util';
 
 import styles from './TransactionList.module.scss';
+import { getTargetNet, Net } from '~/utils/ConfigHelper';
+import GtuDrop from './GtuDrop';
+
+const isMainnet = getTargetNet() === Net.Mainnet;
 
 export default function FiniteTransactionList({
     transactions,
@@ -40,18 +44,21 @@ export default function FiniteTransactionList({
         );
     }
 
-    if (transactions.length === 0) {
-        return (
-            <h3
-                className={clsx(
-                    'flex justifyCenter mV0 pV20',
-                    styles.thickBlueSeparatorTop,
-                    styles.cardPadding
-                )}
-            >
-                No transactions to show for account.
-            </h3>
-        );
+    if (transactions.length === 0 && !loading) {
+        if (isMainnet) {
+            return (
+                <h3
+                    className={clsx(
+                        'flex justifyCenter mV0 pV20',
+                        styles.thickBlueSeparatorTop,
+                        styles.cardPadding
+                    )}
+                >
+                    No transactions to show for account.
+                </h3>
+            );
+        }
+        return <GtuDrop />;
     }
 
     return (

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -1,0 +1,111 @@
+import clsx from 'clsx';
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import SimpleErrorModal from '~/components/SimpleErrorModal';
+import Button from '~/cross-app-components/Button';
+import { insertTransactions } from '~/database/TransactionDao';
+import { chosenAccountSelector } from '~/features/AccountSlice';
+import { reloadTransactions } from '~/features/TransactionSlice';
+import { displayTargetNet, getTargetNet } from '~/utils/ConfigHelper';
+import { gtuDrop } from '~/utils/httpRequests';
+import { secondsSinceUnixEpoch } from '~/utils/timeHelpers';
+import {
+    TransactionKindString,
+    TransactionStatus,
+    TransferTransaction,
+} from '~/utils/types';
+import styles from './TransactionList.module.scss';
+
+const gtuDropAmount = '2000000000';
+
+/**
+ * Sends a GTU drop request to the wallet proxy. If successful a pending
+ * transaction for the GTU drop is inserted into the database, and the
+ * local state is updated so that the transaction will be displayed.
+ * @param the account address to request the GTU drop for
+ */
+async function handleGtuDrop(
+    dispatch: ThunkDispatch<unknown, unknown, AnyAction>,
+    setError: React.Dispatch<React.SetStateAction<string | undefined>>,
+    address?: string
+) {
+    if (!address) {
+        return;
+    }
+
+    let submissionId: string;
+    try {
+        submissionId = await gtuDrop(address);
+    } catch {
+        setError(
+            'The GTU drop service was not reachable. Please try again later.'
+        );
+        return;
+    }
+
+    try {
+        const gtuDropTransaction: TransferTransaction = {
+            transactionHash: submissionId,
+            transactionKind: TransactionKindString.Transfer,
+            toAddress: address,
+            fromAddress: '',
+            status: TransactionStatus.Pending,
+            blockHash: submissionId,
+            blockTime: secondsSinceUnixEpoch(new Date()).toString(),
+            subtotal: gtuDropAmount,
+        };
+        await insertTransactions([gtuDropTransaction]);
+    } catch {
+        setError(
+            'An internal error occurred. Please try again. If the problem persists, please contact support.'
+        );
+        return;
+    }
+
+    dispatch(reloadTransactions());
+}
+
+/**
+ * Component that is used to inform the user about the option
+ * to get a GTU drop, and to ask the wallet proxy for the GTU
+ * drop transfer to the current account.
+ */
+export default function GtuDrop() {
+    const dispatch = useDispatch();
+    const account = useSelector(chosenAccountSelector);
+    const netName = displayTargetNet(getTargetNet());
+    const [error, setError] = useState<string>();
+
+    return (
+        <>
+            <SimpleErrorModal
+                show={Boolean(error)}
+                header="An error occurred"
+                content={error}
+                onClick={() => setError(undefined)}
+            />
+            <div
+                className={clsx(
+                    'flexColumn justifyCenter mV0 pV20',
+                    styles.thickBlueSeparatorTop,
+                    styles.cardPadding
+                )}
+            >
+                <h3 className="textCenter mV0">{netName} GTU drop</h3>
+                <p>
+                    On the Concordium {netName} you can request some GTU to be
+                    deposited to an account to get you started.
+                </p>
+                <Button
+                    onClick={() =>
+                        handleGtuDrop(dispatch, setError, account?.address)
+                    }
+                >
+                    Request GTU
+                </Button>
+            </div>
+        </>
+    );
+}

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -9,6 +9,7 @@ import { insertTransactions } from '~/database/TransactionDao';
 import { chosenAccountSelector } from '~/features/AccountSlice';
 import { reloadTransactions } from '~/features/TransactionSlice';
 import { displayTargetNet, getTargetNet } from '~/utils/ConfigHelper';
+import { getGTUSymbol, microGtuToGtu } from '~/utils/gtu';
 import { gtuDrop } from '~/utils/httpRequests';
 import { secondsSinceUnixEpoch } from '~/utils/timeHelpers';
 import {
@@ -18,7 +19,7 @@ import {
 } from '~/utils/types';
 import styles from './TransactionList.module.scss';
 
-const gtuDropAmount = '2000000000';
+const microGtuDropAmount = '2000000000';
 
 /**
  * Sends a GTU drop request to the wallet proxy. If successful a pending
@@ -54,7 +55,7 @@ async function handleGtuDrop(
             status: TransactionStatus.Pending,
             blockHash: '',
             blockTime: secondsSinceUnixEpoch(new Date()).toString(),
-            subtotal: gtuDropAmount,
+            subtotal: microGtuDropAmount,
         };
         await insertTransactions([gtuDropTransaction]);
     } catch {
@@ -115,7 +116,8 @@ export default function GtuDrop() {
                         }
                     }}
                 >
-                    Request 2000 GTU
+                    Request {getGTUSymbol()}
+                    {microGtuToGtu(microGtuDropAmount)}
                 </Button>
             </div>
         </>

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -52,7 +52,7 @@ async function handleGtuDrop(
             toAddress: address,
             fromAddress: '',
             status: TransactionStatus.Pending,
-            blockHash: submissionId,
+            blockHash: '',
             blockTime: secondsSinceUnixEpoch(new Date()).toString(),
             subtotal: gtuDropAmount,
         };

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -115,7 +115,7 @@ export default function GtuDrop() {
                         }
                     }}
                 >
-                    Request GTU
+                    Request 2000 GTU
                 </Button>
             </div>
         </>

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -77,6 +77,9 @@ export default function GtuDrop() {
     const account = useSelector(chosenAccountSelector);
     const netName = displayTargetNet(getTargetNet());
     const [error, setError] = useState<string>();
+    const [gtuDropButtonActive, setGtuDropButtonActive] = useState<boolean>(
+        true
+    );
 
     return (
         <>
@@ -99,9 +102,18 @@ export default function GtuDrop() {
                     deposited to an account to get you started.
                 </p>
                 <Button
-                    onClick={() =>
-                        handleGtuDrop(dispatch, setError, account?.address)
-                    }
+                    disabled={!gtuDropButtonActive}
+                    onClick={async () => {
+                        if (gtuDropButtonActive) {
+                            setGtuDropButtonActive(false);
+                            await handleGtuDrop(
+                                dispatch,
+                                setError,
+                                account?.address
+                            );
+                            setGtuDropButtonActive(true);
+                        }
+                    }}
                 >
                     Request GTU
                 </Button>

--- a/app/preload/http.ts
+++ b/app/preload/http.ts
@@ -99,8 +99,7 @@ async function getTransactions(
 
 async function gtuDrop(address: string) {
     const response = await walletProxy.put(`/v0/testnetGTUDrop/${address}`);
-    const { submissionId } = response.data;
-    return submissionId;
+    return response.data.submissionId;
 }
 
 const exposedMethods: HttpMethods = {

--- a/app/preload/http.ts
+++ b/app/preload/http.ts
@@ -97,6 +97,12 @@ async function getTransactions(
     return { transactions, full: count === limit };
 }
 
+async function gtuDrop(address: string) {
+    const response = await walletProxy.put(`/v0/testnetGTUDrop/${address}`);
+    const { submissionId } = response.data;
+    return submissionId;
+}
+
 const exposedMethods: HttpMethods = {
     get: httpsGet,
     getTransactions,
@@ -105,6 +111,7 @@ const exposedMethods: HttpMethods = {
         const response = await walletProxy.get('/v0/ip_info');
         return response.data;
     },
+    gtuDrop,
 };
 
 export default exposedMethods;

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -101,6 +101,7 @@ export type HttpMethods = {
         transactionFilter: TransactionFilter
     ) => Promise<IncomingTransaction[]>;
     getIdProviders: () => Promise<IdentityProvider[]>;
+    gtuDrop: (address: string) => Promise<string>;
 };
 
 export type GeneralMethods = {

--- a/app/utils/httpRequests.ts
+++ b/app/utils/httpRequests.ts
@@ -23,6 +23,10 @@ export async function getTransactions(address: string, id = '0') {
     return window.http.getTransactions(address, id);
 }
 
+export async function gtuDrop(address: string) {
+    return window.http.gtuDrop(address);
+}
+
 export async function getNewestTransactions(
     address: string,
     transactionFilter: TransactionFilter


### PR DESCRIPTION
## Purpose
Add the option to get a GTU drop like we can from the mobile reference wallets. For testnet and stagenet.

## Changes
- Added a GTU drop button to the transaction log (similar to how it works in the mobile wallets) if an account has no transactions.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.