### PR TITLE
Show open app text in Ledger status

### DIFF
--- a/app/shell/Status/LedgerStatus.tsx
+++ b/app/shell/Status/LedgerStatus.tsx
@@ -18,12 +18,14 @@ enum Status {
     NewDevice = 'New Device',
     OutDated = 'Outdated',
     Connected = 'Connected',
+    OpenApp = 'Open app',
 }
 
 function getStatusImage(status: Status) {
     switch (status) {
         case Status.NoWallet:
         case Status.OutDated:
+        case Status.OpenApp:
             return RejectedImage;
         case Status.NewDevice:
         case Status.Connected:
@@ -95,6 +97,9 @@ export default function LedgerStatus(): JSX.Element {
             setDisconnected(false);
             setStatusText(Status.Connected);
             submitHandler();
+        } else if (status === LedgerStatusType.OPEN_APP) {
+            setDisconnected(true);
+            setStatusText(Status.OpenApp);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [status]);


### PR DESCRIPTION
## Purpose
Improve the Ledger status when it is connected, but the app is not open.

## Changes
- Display 'Open app' in the status field if connected, but the Concordium app is not open.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.