### PR TITLE
Stop updating node status state on no change

### DIFF
--- a/app/shell/Status/NodeStatus.tsx
+++ b/app/shell/Status/NodeStatus.tsx
@@ -38,8 +38,12 @@ export default function NodeStatus(): JSX.Element {
     );
     const statusText = useSelector((s: RootState) => s.misc.nodeStatus);
     const setStatusText = useCallback(
-        (status: NodeConnectionStatus) => dispatch(setNodeStatus(status)),
-        [dispatch]
+        (status: NodeConnectionStatus) => {
+            if (status !== statusText) {
+                dispatch(setNodeStatus(status));
+            }
+        },
+        [dispatch, statusText]
     );
 
     const setStatus = useCallback(
@@ -72,6 +76,7 @@ export default function NodeStatus(): JSX.Element {
 
     useEffect(() => {
         const controller = new AbortController();
+        controller.start();
         setStatus(controller);
         return () => controller.abort();
     }, [connectionSettings?.value, setStatus]);


### PR DESCRIPTION
## Purpose
I noticed our console was spammed with `setNodeStatus` state updates even when the state was not changing. This makes it so that the state update is only dispatched if it has changed.

## Changes
- Check if the status has changed before updating the status state.
- Start the controller, so that `abort()` actually aborts.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.