### PR TITLE
Fix multi-account report skipping accounts

### DIFF
--- a/app/pages/Accounts/AccountDetailsPage/AccountReport/AccountReport.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/AccountReport/AccountReport.tsx
@@ -85,7 +85,6 @@ export default function AccountReport({ location }: Props) {
                     credentialNumber: number,
                     prfKeySeed: string
                 ) => {
-                    setShowDecrypt({ show: false });
                     resolve({
                         decrypted,
                         address,
@@ -132,6 +131,7 @@ export default function AccountReport({ location }: Props) {
                     accountsToReport.push(account);
                 }
             }
+            setShowDecrypt({ show: false });
             const accountsLength = accountsToReport.length;
 
             if (accountsLength === 0) {


### PR DESCRIPTION
## Purpose

Fix #162.

## Changes

The error was caused by the modal closing and triggering onFinish automatically.
During account report, don't close decrypt modal between accounts.
This prevents the auto rejection of accounts. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
