### PR TITLE
Display identity creation error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   Added a GTU drop option for testnet and stagenet.
+-   In the case of a failed identity, the error details received from the identity provider are now displayed to the user.
 
 ### Changed
 

--- a/app/components/FailedIdentityModal.tsx
+++ b/app/components/FailedIdentityModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ChoiceModal from '~/components/ChoiceModal';
 import routes from '~/constants/routes.json';
@@ -11,15 +11,18 @@ interface Props {
     identityId: number;
     identityName: string;
     isRejected: boolean;
+    detail: string;
 }
 
 /**
- * Modal, which appears on rejected identities/initial accounts.
+ * Modal that should be shown to the user when an identity/initial account
+ * creation has been rejected.
  */
 export default function FailedIdentityModal({
     identityId,
     identityName,
     isRejected,
+    detail,
 }: Props) {
     const [modalOpen, setModalOpen] = useState(false);
     const dispatch = useDispatch();
@@ -35,11 +38,29 @@ export default function FailedIdentityModal({
         }
     }, [isRejected, setModalOpen]);
 
+    const decriptionComponent = useMemo(() => {
+        return (
+            <>
+                <p>
+                    Unfortunately something went wrong with your new identity (
+                    {identityName}) and initial account ({initialAccountName}).
+                </p>
+                <p className="textError textCenter">{detail}</p>
+                <p>
+                    You can either go back and try again, or try again later.
+                    The identity can be removed by deleting the identity card in
+                    the identity view. This will automatically delete the
+                    related initial account as well
+                </p>
+            </>
+        );
+    }, [identityName, initialAccountName, detail]);
+
     return (
         <ChoiceModal
             disableClose
             title="The identity and initial account creation failed"
-            description={`Unfortunately something went wrong with your new identity (${identityName}) and initial account (${initialAccountName}). You can either go back and try again, or try again later. The identity can be removed by deleting the identity card in the identity view. This will automatically delete the related initial account as well.`}
+            description={decriptionComponent}
             open={modalOpen}
             actions={[
                 {

--- a/app/components/FailedIdentityModal.tsx
+++ b/app/components/FailedIdentityModal.tsx
@@ -38,7 +38,7 @@ export default function FailedIdentityModal({
         }
     }, [isRejected, setModalOpen]);
 
-    const decriptionComponent = useMemo(() => {
+    const description = useMemo(() => {
         return (
             <>
                 <p>
@@ -60,7 +60,7 @@ export default function FailedIdentityModal({
         <ChoiceModal
             disableClose
             title="The identity and initial account creation failed"
-            description={decriptionComponent}
+            description={description}
             open={modalOpen}
             actions={[
                 {

--- a/app/components/IdentityCard/FailedIdentityDetails.tsx
+++ b/app/components/IdentityCard/FailedIdentityDetails.tsx
@@ -72,6 +72,7 @@ ${getOS()}`;
                 <p className="textError textCenter">
                     Identity issuance failed.
                 </p>
+                <p className="textError textCenter">{identity.detail}</p>
             </div>
         );
     }
@@ -79,6 +80,7 @@ ${getOS()}`;
     return (
         <div className={clsx('body3 p20', styles.failedDetails)}>
             <p className="textError textCenter">Identity issuance failed.</p>
+            <p className="textError textCenter">{identity.detail}</p>
             {mail && (
                 <>
                     <p className={clsx(styles.failedDetailsLine, 'pV10')}>

--- a/app/components/IdentityCard/FailedIdentityDetails.tsx
+++ b/app/components/IdentityCard/FailedIdentityDetails.tsx
@@ -65,22 +65,27 @@ ${getOS()}`;
 
     const [copied, setCopied] = useTimeoutState(false, 2000);
 
+    const failedDetails = (
+        <>
+            <p className="textError textCenter mB5">
+                Identity issuance failed:
+            </p>
+            <p className="textError textCenter body3 mT0">{identity.detail}</p>
+        </>
+    );
+
     const targetNet = getTargetNet();
     if (targetNet !== Net.Mainnet) {
         return (
             <div className={clsx('body3 p20', styles.failedDetails)}>
-                <p className="textError textCenter">
-                    Identity issuance failed.
-                </p>
-                <p className="textError textCenter">{identity.detail}</p>
+                {failedDetails}
             </div>
         );
     }
 
     return (
         <div className={clsx('body3 p20', styles.failedDetails)}>
-            <p className="textError textCenter">Identity issuance failed.</p>
-            <p className="textError textCenter">{identity.detail}</p>
+            {failedDetails}
             {mail && (
                 <>
                     <p className={clsx(styles.failedDetailsLine, 'pV10')}>

--- a/app/pages/Identities/IdentityView.tsx
+++ b/app/pages/Identities/IdentityView.tsx
@@ -21,6 +21,7 @@ export default function IdentityView() {
                 identityId={identity.id}
                 identityName={identity.name}
                 isRejected={identity.status === IdentityStatus.Rejected}
+                detail={identity.detail}
             />
             <IdentityCard identity={identity} showAttributes canEdit />
         </>

--- a/app/preload/database/identityDao.ts
+++ b/app/preload/database/identityDao.ts
@@ -72,11 +72,14 @@ async function removeIdentity(id: number, trx: Knex.Transaction) {
  * initial account.
  * @param identityId the identity to reject
  */
-async function rejectIdentityAndInitialAccount(identityId: number) {
+async function rejectIdentityAndInitialAccount(
+    identityId: number,
+    detail: string
+) {
     (await knex()).transaction(async (trx) => {
         await trx(identitiesTable)
             .where({ id: identityId })
-            .update({ status: IdentityStatus.Rejected });
+            .update({ status: IdentityStatus.Rejected, detail });
         await trx(accountsTable)
             .where({ identityId, isInitial: 1 })
             .update({ status: AccountStatus.Rejected });

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -256,7 +256,10 @@ export type IdentityMethods = {
     insert: (identity: Partial<Identity> | Identity[]) => Promise<number[]>;
     update: (id: number, updatedValues: Partial<Identity>) => Promise<number>;
     getIdentitiesForWallet: (walletId: number) => Promise<Identity[]>;
-    rejectIdentityAndInitialAccount: (identityId: number) => Promise<void>;
+    rejectIdentityAndInitialAccount: (
+        identityId: number,
+        detail: string
+    ) => Promise<void>;
     removeIdentityAndInitialAccount: (identityId: number) => Promise<void>;
     confirmIdentity: (
         identityId: number,

--- a/app/utils/IdentityStatusPoller.ts
+++ b/app/utils/IdentityStatusPoller.ts
@@ -37,7 +37,10 @@ export async function confirmIdentityAndInitialAccount(
     // The identity provider failed the identity creation request. Clean up the
     // identity and account in the database and refresh the state.
     if (idObjectResponse.error) {
-        await rejectIdentityAndInitialAccount(identityId);
+        await rejectIdentityAndInitialAccount(
+            identityId,
+            idObjectResponse.error.message
+        );
         await loadIdentities(dispatch);
         await loadAccounts(dispatch);
         return;


### PR DESCRIPTION
## Purpose
Notabene now provides error message details in the `detail` field. This PR ensures that we save that information on rejected identities, and that we display the message to the user.

## Changes
- `detail` is saved in the identity table if the identity creation fails.
- the `detail` field is displayed for failed identities.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.