### PR TITLE
Fix shielded balance transfers

### DIFF
--- a/app/utils/rustInterface.ts
+++ b/app/utils/rustInterface.ts
@@ -350,9 +350,10 @@ export async function makeTransferToPublicData(
         accountNumber,
         incomingAmounts: accountEncryptedAmount.incomingAmounts,
         encryptedSelfAmount: accountEncryptedAmount.selfAmount,
-        aggIndex:
+        aggIndex: (
             accountEncryptedAmount.startIndex +
-            BigInt(accountEncryptedAmount.incomingAmounts.length),
+            BigInt(accountEncryptedAmount.incomingAmounts.length)
+        ).toString(),
     };
 
     const transferToPublicData = await worker.postMessage({
@@ -376,9 +377,6 @@ export async function makeTransferToEncryptedData(
         accountNumber,
         incomingAmounts: accountEncryptedAmount.incomingAmounts,
         encryptedSelfAmount: accountEncryptedAmount.selfAmount,
-        aggIndex:
-            accountEncryptedAmount.startIndex +
-            BigInt(accountEncryptedAmount.incomingAmounts.length),
     };
 
     const transferToSecretData = await worker.postMessage({
@@ -404,9 +402,10 @@ export async function makeEncryptedTransferData(
         accountNumber,
         incomingAmounts: accountEncryptedAmount.incomingAmounts,
         encryptedSelfAmount: accountEncryptedAmount.selfAmount,
-        aggIndex:
+        aggIndex: (
             accountEncryptedAmount.startIndex +
-            BigInt(accountEncryptedAmount.incomingAmounts.length),
+            BigInt(accountEncryptedAmount.incomingAmounts.length)
+        ).toString(),
     };
 
     const encryptedTransferData = await worker.postMessage({

--- a/rust-src/aux_functions.rs
+++ b/rust-src/aux_functions.rs
@@ -359,7 +359,8 @@ pub fn create_sec_to_pub_aux(
 
     let incoming_amounts: Vec<EncryptedAmount<ExampleCurve>> = try_get(&v, "incomingAmounts")?;
     let self_amount: EncryptedAmount<ExampleCurve> = try_get(&v, "encryptedSelfAmount")?;
-    let agg_index: EncryptedAmountAggIndex = try_get(&v, "aggIndex")?;
+    let index: u64 = try_get::<String>(&v, "aggIndex")?.parse::<u64>()?;
+    let agg_index = EncryptedAmountAggIndex{ index };
     let to_transfer: Amount = try_get(&v, "amount")?;
 
     let input_amount = incoming_amounts.iter().fold(self_amount, |acc, amount| encrypted_transfers::aggregate(&acc,amount));
@@ -478,7 +479,8 @@ pub fn create_encrypted_transfer_aux(
 
     let incoming_amounts: Vec<EncryptedAmount<ExampleCurve>> = try_get(&v, "incomingAmounts")?;
     let self_amount: EncryptedAmount<ExampleCurve> = try_get(&v, "encryptedSelfAmount")?;
-    let agg_index: EncryptedAmountAggIndex = try_get(&v, "aggIndex")?;
+    let index: u64 = try_get::<String>(&v, "aggIndex")?.parse::<u64>()?;
+    let agg_index = EncryptedAmountAggIndex{ index };
     let to_transfer: Amount = try_get(&v, "amount")?;
 
     let input_amount = incoming_amounts.iter().fold(self_amount, |acc, amount| encrypted_transfers::aggregate(&acc,amount));


### PR DESCRIPTION
## Purpose

After use-node-sdk, creating any of the three types of shielded balance transfers,
did not work. This fixes that.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
