### PR TITLE
Improve performance of account report

### DIFF
--- a/app/preload/accountReport.ts
+++ b/app/preload/accountReport.ts
@@ -253,19 +253,21 @@ async function streamTransactions(
             TransactionOrder.Descending,
             startId
         );
-        const filteredTransactions = incomingTransactions
-            .filter((t) =>
-                fromDate
-                    ? Number(t.blockTime) >= secondsSinceUnixEpoch(fromDate)
-                    : true
-            )
-            .map((txn) => convertIncomingTransaction(txn, account.address));
+
+        let convertedTransactions = incomingTransactions.map((txn) =>
+            convertIncomingTransaction(txn, account.address)
+        );
+        if (fromDate) {
+            convertedTransactions = convertedTransactions.filter(
+                (t) => Number(t.blockTime) >= secondsSinceUnixEpoch(fromDate)
+            );
+        }
 
         // If we filtered away some transactions, then this is the final page we needed to
         // fetch from the wallet proxy, as this means that we have reached the from date (if
         // one was set).
         let more = full;
-        if (filteredTransactions.length < incomingTransactions.length) {
+        if (convertedTransactions.length < incomingTransactions.length) {
             more = false;
         }
 
@@ -282,10 +284,10 @@ async function streamTransactions(
                 entry.prfKeySeed,
                 account.address,
                 global,
-                filteredTransactions
+                convertedTransactions
             );
         } else {
-            transactions = filteredTransactions;
+            transactions = convertedTransactions;
         }
 
         hasMore = more;


### PR DESCRIPTION
## Purpose
Improve the performance of the account report (significantly).

## Changes
- Avoid using `fromDate` and `toDate` in as many queries to the wallet proxy as possible. Instead, use `from` and paginate over that and do the filtering in-memory. The wallet proxy does not perform well if we use queries with the dates.
- Removed filtering based on `smallestBlockTime` as it resulted in skipping transactions that should not have been skipped.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.