### PR TITLE
Support displaying unknown attributes

### DIFF
--- a/app/components/DisplayIdentityAttributes.tsx
+++ b/app/components/DisplayIdentityAttributes.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { AttributeKey } from '@concordium/node-sdk';
 import attributeNamesJson from '~/constants/attributeNames.json';
 import SidedRow from '~/components/SidedRow';
-import { AttributeKeyName } from '~/utils/types';
+import { AttributeKeyName, ClassName } from '~/utils/types';
 import {
     formatAttributeValue,
     compareAttributes,
@@ -10,21 +10,22 @@ import {
 
 const attributeNames: Record<string, string> = attributeNamesJson;
 
-interface Props {
-    revealedAttributes: Record<AttributeKey, string>;
+interface Props extends ClassName {
+    attributes: Record<AttributeKey | string, string>;
 }
 
 /**
- *  Displays the provided revealed attributes.
+ *  Displays the provided attributes.
  */
 export default function DisplayIdentityAttributes({
-    revealedAttributes,
+    attributes,
+    className,
 }: Props): JSX.Element | null {
-    const attributeKeys = Object.keys(revealedAttributes);
+    const attributeKeys = Object.keys(attributes);
 
     if (attributeKeys.length === 0) {
         return (
-            <div className="pT10">
+            <div className={className}>
                 This credential has no identity data revealed
             </div>
         );
@@ -36,12 +37,12 @@ export default function DisplayIdentityAttributes({
                 .sort(compareAttributes)
                 .map((attributeKey: AttributeKeyName) => (
                     <SidedRow
-                        className="pT10"
+                        className={className}
                         key={attributeKey}
-                        left={attributeNames[attributeKey]}
+                        left={attributeNames[attributeKey] || attributeKey}
                         right={formatAttributeValue(
                             attributeKey,
-                            revealedAttributes[attributeKey]
+                            attributes[attributeKey]
                         )}
                     />
                 ))}

--- a/app/components/IdentityCard/IdentityCard.tsx
+++ b/app/components/IdentityCard/IdentityCard.tsx
@@ -13,20 +13,16 @@ import {
     AttributeKeyName,
 } from '~/utils/types';
 import { formatDate } from '~/utils/timeHelpers';
+import { filterRecordEntries } from '~/utils/basicHelpers';
 import Card from '~/cross-app-components/Card';
-import SidedRow from '../SidedRow';
-import {
-    attributeNamesMap,
-    formatAttributeValue,
-    compareAttributes,
-    IDENTITY_NAME_MAX_LENGTH,
-} from '~/utils/identityHelpers';
+import { IDENTITY_NAME_MAX_LENGTH } from '~/utils/identityHelpers';
 import Form from '../Form';
 import Button from '~/cross-app-components/Button';
 import { useUpdateEffect } from '~/utils/hooks';
 import { editIdentityName } from '~/features/IdentitySlice';
 import DeleteIdentity from './DeleteIdentity';
 import FailedIdentityDetails from './FailedIdentityDetails';
+import DisplayIdentityAttributes from '~/components/DisplayIdentityAttributes';
 
 import styles from './IdentityCard.module.scss';
 
@@ -185,31 +181,15 @@ function IdentityListElement({
             </div>
             {showAttributes && !isRecovered && identityObject && (
                 <div className={styles.details}>
-                    {Object.entries(
-                        identityObject.attributeList.chosenAttributes ?? {}
-                    )
-                        .filter(
-                            ([k]) =>
+                    <DisplayIdentityAttributes
+                        className={styles.detailsRow}
+                        attributes={filterRecordEntries(
+                            identityObject.attributeList.chosenAttributes ?? {},
+                            (k) =>
                                 showAttributes === true ||
                                 showAttributes.includes(k as AttributeKeyName)
-                        )
-                        .sort(([k1], [k2]) =>
-                            compareAttributes(
-                                k1 as AttributeKeyName,
-                                k2 as AttributeKeyName
-                            )
-                        )
-                        .map(([k, v]) => (
-                            <SidedRow
-                                className={styles.detailsRow}
-                                key={k}
-                                left={attributeNamesMap[k as AttributeKeyName]}
-                                right={formatAttributeValue(
-                                    k as AttributeKeyName,
-                                    v
-                                )}
-                            />
-                        ))}
+                        )}
+                    />
                 </div>
             )}
             {showAttributes &&

--- a/app/pages/Accounts/AccountDetailsPage/CredentialInformation/CredentialInformation.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/CredentialInformation/CredentialInformation.tsx
@@ -18,7 +18,7 @@ import {
     getCredId,
 } from '~/utils/credentialHelper';
 import { identitiesSelector } from '~/features/IdentitySlice';
-import DisplayIdentityAttributes from './DisplayIdentityAttributes';
+import DisplayIdentityAttributes from '~/components/DisplayIdentityAttributes';
 import IconButton from '~/cross-app-components/IconButton';
 
 import styles from './CredentialInformation.module.scss';
@@ -151,7 +151,8 @@ export default function CredentialInformation({ account, accountInfo }: Props) {
                         <div className={styles.attributesRow}>
                             <em>Revealed attributes:</em>
                             <DisplayIdentityAttributes
-                                revealedAttributes={c.policy.revealedAttributes}
+                                className="pT10"
+                                attributes={c.policy.revealedAttributes}
                             />
                         </div>
                     </div>

--- a/app/utils/basicHelpers.ts
+++ b/app/utils/basicHelpers.ts
@@ -190,3 +190,20 @@ export function mapRecordValues<K extends string | number | symbol, V, T>(
         return acc;
     }, result);
 }
+
+/**
+ * Helper to run a filter on the entries of a record.
+ */
+export function filterRecordEntries<K extends string | number | symbol, V>(
+    record: Record<K, V>,
+    filter: (key: K, value: V) => boolean
+): Record<K, V> {
+    const result = {} as Record<K, V>;
+    const entries = Object.entries(record) as [K, V][];
+    return entries.reduce((acc, [k, v]) => {
+        if (filter(k, v)) {
+            acc[k as K] = v;
+        }
+        return acc;
+    }, result);
+}

--- a/app/utils/identityHelpers.ts
+++ b/app/utils/identityHelpers.ts
@@ -69,10 +69,11 @@ const parseDocType = (docType: DocumentType) => {
     }
 };
 
-export const formatAttributeValue = (
+export function formatAttributeValue(
     key: AttributeKeyName,
     value: ChosenAttributes[typeof key]
-): string => {
+): string;
+export function formatAttributeValue(key: string, value: string): string {
     switch (key) {
         case 'idDocExpiresAt':
         case 'idDocIssuedAt':
@@ -85,13 +86,29 @@ export const formatAttributeValue = (
         default:
             return value;
     }
-};
+}
 
+/**
+ * Compare two attribute key names.
+ * Tags, that are not in AttributeKey, are considered larger than those in AttributeKey.
+ * This is to ensure that in a sorted ascending list, unknown attributes are placed at the end of the list.
+ */
 export function compareAttributes(
-    AttributeTag1: AttributeKeyName,
-    AttributeTag2: AttributeKeyName
+    attributeTag1: AttributeKeyName | string,
+    attributeTag2: AttributeKeyName | string
 ) {
-    return AttributeKey[AttributeTag1] - AttributeKey[AttributeTag2];
+    const attr1 = AttributeKey[attributeTag1 as AttributeKeyName];
+    const attr2 = AttributeKey[attributeTag2 as AttributeKeyName];
+    if (attr1 === undefined && attr2 === undefined) {
+        return attributeTag1.localeCompare(attributeTag2);
+    }
+    if (attr1 === undefined) {
+        return 1;
+    }
+    if (attr2 === undefined) {
+        return -1;
+    }
+    return attr1 - attr2;
 }
 
 export function getSessionId(identity: Identity) {


### PR DESCRIPTION
## Purpose

Implement #160.

## Changes

Move DisplayIdentityAttributes to components, and have IdentityCard use it.
Handle unknown attributes by displaying those keys raw.
When sorting, unknown attributes are sorted higher.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
