### PR TITLE
Fix baker keys export

### DIFF
--- a/app/components/ExportBakerCredentials.tsx
+++ b/app/components/ExportBakerCredentials.tsx
@@ -28,15 +28,20 @@ export default function ExportBakerCredentials({
         if (accountInfo === undefined) {
             return;
         }
+        // We have to manually insert the bakerId into the JSON, because JS integers only supports 53bit precision, and JSON.stringify doesn't handle bigints.
         const fileString = JSON.stringify({
-            bakerId: accountInfo.accountIndex.toString(),
+            bakerId: 0, // Placeholder
             aggregationSignKey: bakerKeys.aggregationSecret,
             aggregationVerifyKey: bakerKeys.aggregationPublic,
             electionPrivateKey: bakerKeys.electionSecret,
             electionVerifyKey: bakerKeys.electionPublic,
             signatureSignKey: bakerKeys.signatureSecret,
             signatureVerifyKey: bakerKeys.signaturePublic,
-        });
+        }).replace(
+            '"bakerId":0',
+            `"bakerId":${accountInfo.accountIndex.toString()}`
+        );
+
         const success = await saveFile(fileString, {
             title: 'Save Baker Credentials',
             defaultPath: 'baker-credentials.json',


### PR DESCRIPTION
## Purpose

Fix baker keys export not following the format that the node expects. 

## Changes

Now manually puts bakerId into the JSON output, to make it a JSON number.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
