### PR TITLE
Fix issues with finding min and max id

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -93,7 +93,7 @@ async function getNewTransactions(
 ): Promise<TransferTransaction[]> {
     // As the transactions in the state are in descending order on their id, the maxId
     // can be found as the first item with an id (if any exist).
-    const maxId = transactionsInState.map((t) => t.id).filter(isDefined)[0];
+    const maxId = transactionsInState.find((t) => t.id !== undefined)?.id;
 
     const transactions: IncomingTransaction[] = [];
     let full = true;


### PR DESCRIPTION
## Purpose
The reducer functions used to find `minId` and `maxId` used string comparisons, which lead to bugs where the transaction loading would keep loading the same transactions, instead of getting new transactions. This PR fixes that by calculating the correct `minId` and `maxId`.

## Changes
As the transaction list state is sorted descendingly on the `id` field, the following changes are made to fix the issue:
- `maxId` is be found as the first item in the transaction state with an `id`.
- `minId` is found as the last item in the transaction state with an `id`.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.