### PR TITLE
Stop attempting to decrypt failed encrypted transfers

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -26,7 +26,6 @@ import {
     Dispatch,
     TransferTransactionWithNames,
     Account,
-    TransactionKindString,
     IncomingTransaction,
 } from '../utils/types';
 import {
@@ -45,6 +44,7 @@ import { GetTransactionsOutput } from '~/preload/preloadTypes';
 import { findEntries } from '~/database/DecryptedAmountsDao';
 import { getActiveBooleanFilters } from '~/utils/accountHelpers';
 import * as errorMessages from '~/constants/errorMessages.json';
+import { isSuccessfulEncryptedTransaction } from '~/utils/decryptHelpers';
 
 export const transactionLogPageSize = 100;
 
@@ -140,13 +140,8 @@ async function enrichWithDecryptedAmounts(
     withDecryptedAmounts: TransferTransaction[];
     allDecrypted: boolean;
 }> {
-    const encryptedTypes = [
-        TransactionKindString.EncryptedAmountTransfer,
-        TransactionKindString.EncryptedAmountTransferWithMemo,
-    ];
-
-    const encryptedTransactions = transactions.filter((t) =>
-        encryptedTypes.includes(t.transactionKind)
+    const encryptedTransactions = transactions.filter(
+        isSuccessfulEncryptedTransaction
     );
     const decryptedAmounts = await findEntries(
         encryptedTransactions.map(
@@ -156,7 +151,7 @@ async function enrichWithDecryptedAmounts(
 
     let allDecrypted = true;
     const withDecryptedAmounts = transactions.map((t) => {
-        if (!encryptedTypes.includes(t.transactionKind)) {
+        if (!isSuccessfulEncryptedTransaction(t)) {
             return t;
         }
 

--- a/app/pages/Accounts/DecryptComponent.tsx
+++ b/app/pages/Accounts/DecryptComponent.tsx
@@ -6,11 +6,7 @@ import {
     shieldedTransactionsSelector,
     updateTransactionFields,
 } from '~/features/TransactionSlice';
-import {
-    Account,
-    TransactionKindString,
-    TransactionStatus,
-} from '~/utils/types';
+import { Account } from '~/utils/types';
 import ConcordiumLedgerClient from '~/features/ledger/ConcordiumLedgerClient';
 import Ledger from '~/components/ledger/Ledger';
 import { asyncNoOp } from '~/utils/basicHelpers';
@@ -19,7 +15,9 @@ import Button from '~/cross-app-components/Button';
 import findLocalDeployedCredentialWithWallet from '~/utils/credentialHelper';
 import errorMessages from '~/constants/errorMessages.json';
 import { findEntries, insert } from '~/database/DecryptedAmountsDao';
-import decryptTransactions from '~/utils/decryptHelpers';
+import decryptTransactions, {
+    isSuccessfulEncryptedTransaction,
+} from '~/utils/decryptHelpers';
 
 interface Props {
     account: Account;
@@ -34,18 +32,9 @@ interface Props {
 export default function DecryptComponent({ account, onDecrypt }: Props) {
     const dispatch = useDispatch();
     const global = useSelector(globalSelector);
-    const shieldedTransactions = useSelector(shieldedTransactionsSelector)
-        .filter((t) =>
-            [
-                TransactionKindString.EncryptedAmountTransfer,
-                TransactionKindString.EncryptedAmountTransferWithMemo,
-            ].includes(t.transactionKind)
-        )
-        .filter(
-            (t) =>
-                t.status !== TransactionStatus.Pending &&
-                t.status !== TransactionStatus.Rejected
-        );
+    const shieldedTransactions = useSelector(
+        shieldedTransactionsSelector
+    ).filter(isSuccessfulEncryptedTransaction);
 
     async function ledgerCall(
         ledger: ConcordiumLedgerClient,

--- a/app/utils/decryptHelpers.ts
+++ b/app/utils/decryptHelpers.ts
@@ -1,5 +1,35 @@
 import { decryptAmounts } from './rustInterface';
-import { Global, TransferTransaction } from './types';
+import {
+    Global,
+    TransactionKindString,
+    TransactionStatus,
+    TransferTransaction,
+} from './types';
+
+const encryptedTypes = [
+    TransactionKindString.EncryptedAmountTransfer,
+    TransactionKindString.EncryptedAmountTransferWithMemo,
+];
+
+/**
+ * Checks whether a transaction is an encrypted transfer that is successful, as in
+ * not being a pending, rejected or failed transaction. Checking for this means that
+ * one can assume that the 'encrypted' field is present.
+ * @param transaction the transaction to test
+ * @returns true if the transaction is an encrypted transfer (with or without memo), and not pending, rejected or failed.
+ */
+export function isSuccessfulEncryptedTransaction(
+    transaction: TransferTransaction
+) {
+    return (
+        encryptedTypes.includes(transaction.transactionKind) &&
+        ![
+            TransactionStatus.Pending,
+            TransactionStatus.Rejected,
+            TransactionStatus.Failed,
+        ].includes(transaction.status)
+    );
+}
 
 /**
  * Decrypts the encrypted transfers in the provided transaction list. This is


### PR DESCRIPTION
## Purpose
Currently we will attempt to decrypt a shielded transfer that has failed. This throws an error because such a transaction does not have the `encrypted` field anymore.

## Changes
- Filter on status on the transactions before assuming they are to be decrypted.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.