### PR TITLE
Fix transaction loading

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -27,6 +27,8 @@ import {
     TransferTransactionWithNames,
     Account,
     IncomingTransaction,
+    TransactionFilter,
+    BooleanFilters,
 } from '../utils/types';
 import {
     isShieldedBalanceTransaction,
@@ -72,10 +74,58 @@ interface LoadTransactionsArgs {
      * It will also make the load always run, even though subsequent loads are dispatched before this finishes.
      */
     force?: boolean;
+    /**
+     * If true only shielded transactions will be loaded.
+     */
+    loadShielded: boolean;
 }
 
 let latestLoadingRequestId: string | undefined;
 const forceLock = new Mutex();
+
+/**
+ * Converts a filter into a filter that only includes transaction
+ * types that affect the shielded balance.
+ * @param filter the transaction filter to convert
+ */
+function shieldedOnlyFilter(filter: TransactionFilter): TransactionFilter {
+    // We use this required type to ensure that if a new transaction type
+    // is added, then the compiler will complain.
+    const allFalseFilter: Required<BooleanFilters> = {
+        encryptedAmountTransfer: false,
+        encryptedAmountTransferWithMemo: false,
+        transferToEncrypted: false,
+        transferToPublic: false,
+        addBaker: false,
+        bakingReward: false,
+        blockReward: false,
+        deployModule: false,
+        finalizationReward: false,
+        initContract: false,
+        registerData: false,
+        removeBaker: false,
+        transfer: false,
+        transferWithMemo: false,
+        transferWithSchedule: false,
+        transferWithScheduleAndMemo: false,
+        update: false,
+        updateBakerKeys: false,
+        updateCredentials: false,
+        updateCredentialKeys: false,
+        updateBakerStake: false,
+        updateBakerRestakeEarnings: false,
+    };
+
+    return {
+        ...allFalseFilter,
+        encryptedAmountTransfer: filter.encryptedAmountTransfer,
+        encryptedAmountTransferWithMemo: filter.encryptedAmountTransferWithMemo,
+        transferToEncrypted: filter.transferToEncrypted,
+        transferToPublic: filter.transferToPublic,
+        fromDate: filter.fromDate,
+        toDate: filter.toDate,
+    };
+}
 
 /**
  * Get any transactions that are newer than the newest transaction in the local state. The
@@ -85,11 +135,13 @@ const forceLock = new Mutex();
  * @param account the account to get new transactions for
  * @param transactions the current transactions in the state, assumed to be sorted descendingly
  * @param limit the maximum number of transactions to ask the wallet proxy for
+ * @param loadShielded whether the transactions that should be retrieved are shielded transactions or not
  */
 async function getNewTransactions(
     account: Account,
     transactionsInState: TransferTransaction[],
-    limit: number
+    limit: number,
+    loadShielded: boolean
 ): Promise<TransferTransaction[]> {
     // As the transactions in the state are in descending order on their id, the maxId
     // can be found as the first item with an id (if any exist).
@@ -97,26 +149,26 @@ async function getNewTransactions(
 
     const transactions: IncomingTransaction[] = [];
     let full = true;
-    let currentId = maxId;
+    let currentMaxId = maxId;
+    const filter = loadShielded
+        ? shieldedOnlyFilter(account.transactionFilter)
+        : account.transactionFilter;
 
     // We have to ask for transactions until there are no more. This is needed as we could
     // receive more than ${limit} transactions in one query to the wallet proxy.
     while (full) {
         const transactionsResponseFromWalletProxy = await getTransactionsAscending(
             account.address,
-            account.transactionFilter,
+            filter,
             limit,
-            currentId
+            currentMaxId
         );
 
         transactions.push(...transactionsResponseFromWalletProxy.transactions);
         if (transactionsResponseFromWalletProxy.transactions.length === 0) {
             full = false;
         } else {
-            currentId =
-                transactionsResponseFromWalletProxy.transactions[
-                    transactionsResponseFromWalletProxy.transactions.length - 1
-                ].id;
+            currentMaxId = transactionsResponseFromWalletProxy.maxId;
             full = transactionsResponseFromWalletProxy.full;
         }
     }
@@ -170,6 +222,62 @@ async function enrichWithDecryptedAmounts(
     return { withDecryptedAmounts, allDecrypted };
 }
 
+async function getTransactions(
+    accountAddress: string,
+    filter: TransactionFilter,
+    size: number,
+    fromMinId: string | undefined,
+    rejectIfInvalid: (reason: string) => void
+): Promise<{ transactions: TransferTransaction[]; more: boolean }> {
+    const loadedTransactions: IncomingTransaction[] = [];
+    let fetchMore = true;
+    let fullResult = false;
+    let currentMinId = fromMinId;
+
+    try {
+        while (fetchMore) {
+            rejectIfInvalid(
+                'Load of transactions from wallet proxy has been aborted.'
+            );
+            const {
+                transactions,
+                full,
+                minId,
+            } = await getTransactionsDescending(
+                accountAddress,
+                filter,
+                size,
+                currentMinId
+            );
+
+            loadedTransactions.push(...transactions);
+
+            // If the result from the wallet proxy was full, but the number of transactions
+            // were fewer than a "full page", then this means we filtered away some results in-memory. In this
+            // case we should gather more transactions to retrieve a "full page" if possible.
+            if (full && transactions.length < size) {
+                currentMinId = minId;
+            } else {
+                // In this case we either received all possible transactions from the wallet proxy
+                // with the currently applied filter, or the page was a full page where no transaction
+                // was filtered on our application side. This means we can stop.
+                fetchMore = false;
+
+                // Save whether there are more transactions that could be fetched if wanted.
+                fullResult = full;
+            }
+        }
+    } catch (e) {
+        throw new Error(errorMessages.unableToReachWalletProxy);
+    }
+
+    const transactions = loadedTransactions.map((t) =>
+        convertIncomingTransaction(t, accountAddress)
+    );
+
+    return { transactions, more: fullResult };
+}
+
 /**
  * Load transactions from the wallet proxy and pending transactions
  * from the database. The transactions retrieved are filtered according
@@ -182,6 +290,7 @@ export const loadTransactions = createAsyncThunk(
             append = false,
             size = transactionLogPageSize,
             force = false,
+            loadShielded,
         }: LoadTransactionsArgs,
         { getState, dispatch, requestId, signal }
     ) => {
@@ -213,23 +322,17 @@ export const loadTransactions = createAsyncThunk(
             .map((t) => t.id)
             .filter(isDefined);
         const minId = transactionIdArray[transactionIdArray.length - 1];
+        const filter = loadShielded
+            ? shieldedOnlyFilter(account.transactionFilter)
+            : account.transactionFilter;
 
         try {
-            rejectIfInvalid('Load of transactions on wallet proxy aborted');
-            let transactionsResponseFromWalletProxy;
-            try {
-                transactionsResponseFromWalletProxy = await getTransactionsDescending(
-                    account.address,
-                    account.transactionFilter,
-                    size,
-                    append ? minId : undefined
-                );
-            } catch (e) {
-                throw new Error(errorMessages.unableToReachWalletProxy);
-            }
-
-            const transactions = transactionsResponseFromWalletProxy.transactions.map(
-                (txn) => convertIncomingTransaction(txn, account.address)
+            const { transactions, more } = await getTransactions(
+                account.address,
+                filter,
+                size,
+                append ? minId : undefined,
+                rejectIfInvalid
             );
 
             const {
@@ -269,7 +372,7 @@ export const loadTransactions = createAsyncThunk(
 
             return {
                 transactions: [...pendingTransactions, ...withDecryptedAmounts],
-                more: transactionsResponseFromWalletProxy.full,
+                more,
             };
         } finally {
             // Push release of lock to end of async queue, as this will wait for redux to update with loaded transactions.
@@ -280,10 +383,7 @@ export const loadTransactions = createAsyncThunk(
 
 export const loadNewTransactions = createAsyncThunk(
     ActionTypePrefix.Update,
-    async (
-        { size = transactionLogPageSize }: LoadTransactionsArgs,
-        { getState, dispatch }
-    ) => {
+    async (input: { loadNewShielded: boolean }, { getState, dispatch }) => {
         const state = getState() as RootState;
         const account = chosenAccountSelector(state);
 
@@ -294,7 +394,8 @@ export const loadNewTransactions = createAsyncThunk(
         const transactions = await getNewTransactions(
             account,
             state.transactions.transactions,
-            size
+            transactionLogPageSize,
+            input.loadNewShielded
         );
 
         // Filter out any transactions that are already in the state.
@@ -330,7 +431,10 @@ export const loadNewTransactions = createAsyncThunk(
  */
 export const reloadTransactions = createAsyncThunk(
     ActionTypePrefix.Reload,
-    async (_, { dispatch, getState, signal }) => {
+    async (
+        input: { loadShielded: boolean },
+        { dispatch, getState, signal }
+    ) => {
         // If a forced load is running, wait for it to finish, to reload with updated length of transactions.
         await forceLock.waitForUnlock();
 
@@ -345,6 +449,7 @@ export const reloadTransactions = createAsyncThunk(
         const load = dispatch(
             loadTransactions({
                 size: Math.max(transactions.length, transactionLogPageSize),
+                loadShielded: input.loadShielded,
             })
         );
 

--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -252,10 +252,9 @@ async function getTransactions(
 
             loadedTransactions.push(...transactions);
 
-            // If the result from the wallet proxy was full, but the number of transactions
-            // were fewer than a "full page", then this means we filtered away some results in-memory. In this
-            // case we should gather more transactions to retrieve a "full page" if possible.
-            if (full && transactions.length < size) {
+            // If we got a full page from the wallet proxy, but after filtering it did not
+            // result in a full local page, then we have to gather more transactions.
+            if (full && loadedTransactions.length < size) {
                 currentMinId = minId;
             } else {
                 // In this case we either received all possible transactions from the wallet proxy

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -65,7 +65,7 @@ async function handleGtuDrop(
         return;
     }
 
-    dispatch(reloadTransactions({ loadShielded: false }));
+    dispatch(reloadTransactions({ onlyLoadShielded: false }));
 }
 
 /**

--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -65,7 +65,7 @@ async function handleGtuDrop(
         return;
     }
 
-    dispatch(reloadTransactions());
+    dispatch(reloadTransactions({ loadShielded: false }));
 }
 
 /**

--- a/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
+++ b/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
@@ -21,6 +21,7 @@ import {
     loadingTransactionsSelector,
     loadTransactions,
     transactionLogPageSize,
+    viewingShieldedSelector,
 } from '~/features/TransactionSlice';
 import TransactionListHeader, {
     transactionListHeaderHeight,
@@ -85,6 +86,7 @@ export default function InfiniteTransactionList({
     const dispatch = useThunkDispatch();
     const loading = useSelector(loadingTransactionsSelector);
     const hasMore = useSelector(hasMoreTransactionsSelector);
+    const isViewingShielded = useSelector(viewingShieldedSelector);
     const [error, setError] = useState<string | undefined>();
 
     const loadMore = useCallback(async () => {
@@ -96,6 +98,7 @@ export default function InfiniteTransactionList({
                 showLoading: true,
                 append: true,
                 force: true,
+                loadShielded: isViewingShielded,
             })
         );
         load.then(unwrapResult).catch((e) => {
@@ -107,7 +110,7 @@ export default function InfiniteTransactionList({
         if (abortRef !== undefined) {
             abortRef.current = load.abort;
         }
-    }, [dispatch, loading, hasMore, abortRef, error]);
+    }, [dispatch, loading, hasMore, abortRef, error, isViewingShielded]);
 
     const groups = useTransactionGroups(transactions);
     const headersAndTransactions = groups.flat(2);

--- a/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
+++ b/app/pages/Accounts/TransactionList/InfiniteTransactionList.tsx
@@ -98,7 +98,7 @@ export default function InfiniteTransactionList({
                 showLoading: true,
                 append: true,
                 force: true,
-                loadShielded: isViewingShielded,
+                onlyLoadShielded: isViewingShielded,
             })
         );
         load.then(unwrapResult).catch((e) => {

--- a/app/pages/Accounts/useAccountSync.ts
+++ b/app/pages/Accounts/useAccountSync.ts
@@ -34,11 +34,6 @@ export default function useAccountSync(onError: (message: string) => void) {
     const viewingShielded = useSelector(viewingShieldedSelector);
     const abortUpdateRef = useRef(noOp);
     const [loadIsDone, setIsLoadDone] = useState(false);
-    // A change to the newTransactionsFlag is used to signal that new
-    // transactions are available and should be loaded.
-    const [newTransactionsFlag, setNewTransactionsFlag] = useState<boolean>(
-        false
-    );
     const accountInfoLoaded = Boolean(accountInfo);
 
     // Periodically update the account info to keep it in sync
@@ -70,27 +65,35 @@ export default function useAccountSync(onError: (message: string) => void) {
         []
     );
 
-    const newTransactionsDependencyArray = [
-        accountInfo?.accountAmount,
-        JSON.stringify(accountInfo?.accountEncryptedAmount.incomingAmounts),
-    ];
+    // Load any new shielded transactions if the shielded amount changes.
     useEffect(() => {
-        if (loadIsDone) {
-            setNewTransactionsFlag(!newTransactionsFlag);
+        if (
+            loadIsDone &&
+            viewingShielded &&
+            !account?.transactionFilter.toDate
+        ) {
+            const load = dispatch(
+                loadNewTransactions({ loadNewShielded: true })
+            );
+            return () => {
+                load.abort();
+            };
         }
+        return () => {};
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, newTransactionsDependencyArray);
+    }, [JSON.stringify(accountInfo?.accountEncryptedAmount.incomingAmounts)]);
 
     // Load any new transactions if the account amount changes, as that indicates that a
     // transaction affected the account.
     useEffect(() => {
-        if (loadIsDone) {
+        if (
+            loadIsDone &&
+            !viewingShielded &&
+            !account?.transactionFilter.toDate
+        ) {
             const load = dispatch(
-                loadNewTransactions({
-                    showLoading: true,
-                })
+                loadNewTransactions({ loadNewShielded: false })
             );
-
             return () => {
                 load.abort();
             };
@@ -98,7 +101,7 @@ export default function useAccountSync(onError: (message: string) => void) {
 
         return () => {};
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [newTransactionsFlag]);
+    }, [accountInfo?.accountAmount]);
 
     // Re-load transactions entirely from the wallet proxy if:
     // - the filter is changed
@@ -128,6 +131,7 @@ export default function useAccountSync(onError: (message: string) => void) {
             loadTransactions({
                 showLoading: true,
                 force: true,
+                loadShielded: viewingShielded,
             })
         );
         load.then(unwrapResult)

--- a/app/preload/http.ts
+++ b/app/preload/http.ts
@@ -127,7 +127,24 @@ async function getTransactions(
         transactions
     );
 
-    return { transactions: filteredTransactions, full: count === limit };
+    let minId;
+    let maxId;
+    if (transactions.length > 0) {
+        if (order === TransactionOrder.Descending) {
+            minId = transactions[transactions.length - 1].id;
+            maxId = transactions[0].id;
+        } else {
+            maxId = transactions[transactions.length - 1].id;
+            minId = transactions[0].id;
+        }
+    }
+
+    return {
+        transactions: filteredTransactions,
+        full: count === limit,
+        minId,
+        maxId,
+    };
 }
 
 async function gtuDrop(address: string) {

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -138,6 +138,8 @@ export type CryptoMethods = {
 export type GetTransactionsResult = {
     transactions: IncomingTransaction[];
     full: boolean;
+    minId?: string;
+    maxId?: string;
 };
 
 export interface HttpGetResponse<T> {


### PR DESCRIPTION
## Purpose
In some cases not all transactions were successfully loaded from the wallet proxy. This change updates the loading of transactions from the wallet proxy, so that we keep paginating until a full page is loaded, or until all transactions are loaded. This should ensure that we will not have missing transactions.

## Changes
- Use transaction filter when loading shielded transactions. This also means that the wallet proxy will not be queried for reward transactions when we load shielded transactions.
- Filter away incoming shielded transactions when showing normal balance.
- When loading transactions keep loading until a full page (after filtering) has been received.
- Only load new transactions (on balance change, encrypted balance change) if no `toDate` has been set.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.