### PR TITLE
Fix balance button hitbox

### DIFF
--- a/app/pages/Accounts/AccountBalanceView/AccountBalanceView.module.scss
+++ b/app/pages/Accounts/AccountBalanceView/AccountBalanceView.module.scss
@@ -42,6 +42,7 @@
 
 .viewingShieldedButton {
     text-decoration: underline;
+    z-index: 1;
 }
 
 .active {


### PR DESCRIPTION
## Purpose

Fix that in the account view, You could only click on the balance button's _balan_ part.

## Changes

Gave the viewing shielded buttons a higher z-index.

