### PR TITLE
Bugfix: Shielded balance becomes locked after making a shielded transfer

### DIFF
--- a/app/pages/Accounts/SubmitTransaction/SubmitTransaction.tsx
+++ b/app/pages/Accounts/SubmitTransaction/SubmitTransaction.tsx
@@ -244,18 +244,18 @@ export default function SubmitTransaction({ location }: Props) {
         const response = await sendTransaction(serializedTransaction);
 
         if (response) {
-            // Save the decrypted amount for shielded transfers, so the user doesn't have to decrypt them later.
-            if (
-                instanceOfEncryptedTransfer(transaction) ||
-                instanceOfEncryptedTransferWithMemo(transaction)
-            ) {
-                await insert({
-                    transactionHash,
-                    amount: transaction.payload.plainTransferAmount,
-                });
-            }
-
             try {
+                // Save the decrypted amount for shielded transfers, so the user doesn't have to decrypt them later.
+                if (
+                    instanceOfEncryptedTransfer(transaction) ||
+                    instanceOfEncryptedTransferWithMemo(transaction)
+                ) {
+                    await insert({
+                        transactionHash,
+                        amount: transaction.payload.plainTransferAmount,
+                    });
+                }
+
                 // If an error happens here, it only means the transaction couldn't be added as pending, so no reason to show user an error.
                 const convertedTransaction = await addPendingTransaction(
                     transaction,

--- a/app/utils/TransactionStatusPoller.ts
+++ b/app/utils/TransactionStatusPoller.ts
@@ -11,7 +11,6 @@ import {
     UpdateAccountCredentials,
     Transaction,
     TransferTransaction,
-    TransactionKindString,
 } from './types';
 import {
     confirmTransaction,
@@ -33,7 +32,6 @@ import {
     insertExternalCredentials,
     removeExternalCredentials,
 } from '~/features/CredentialSlice';
-import { insert } from '~/database/DecryptedAmountsDao';
 
 /**
  * Given an UpdateAccountCredentials transaction, update the local state
@@ -70,19 +68,6 @@ async function ShieldedTransferConsequence(
     const { newSelfEncryptedAmount, remainingDecryptedAmount } = parse(
         transaction.encrypted
     );
-    // Save the decrypted amount for shielded transfers, so the user doesn't have to decrypt them later.
-    if (
-        [
-            TransactionKindString.EncryptedAmountTransfer,
-            TransactionKindString.EncryptedAmountTransferWithMemo,
-        ].includes(transaction.transactionKind) &&
-        transaction.decryptedAmount
-    ) {
-        await insert({
-            transactionHash: transaction.transactionHash,
-            amount: transaction.decryptedAmount,
-        });
-    }
     return updateShieldedBalance(
         dispatch,
         transaction.fromAddress,

--- a/app/utils/TransactionStatusPoller.ts
+++ b/app/utils/TransactionStatusPoller.ts
@@ -11,6 +11,7 @@ import {
     UpdateAccountCredentials,
     Transaction,
     TransferTransaction,
+    TransactionKindString,
 } from './types';
 import {
     confirmTransaction,
@@ -69,7 +70,14 @@ async function ShieldedTransferConsequence(
     const { newSelfEncryptedAmount, remainingDecryptedAmount } = parse(
         transaction.encrypted
     );
-    if (transaction.decryptedAmount) {
+    // Save the decrypted amount for shielded transfers, so the user doesn't have to decrypt them later.
+    if (
+        [
+            TransactionKindString.EncryptedAmountTransfer,
+            TransactionKindString.EncryptedAmountTransferWithMemo,
+        ].includes(transaction.transactionKind) &&
+        transaction.decryptedAmount
+    ) {
         await insert({
             transactionHash: transaction.transactionHash,
             amount: transaction.decryptedAmount,

--- a/app/utils/TransactionStatusPoller.ts
+++ b/app/utils/TransactionStatusPoller.ts
@@ -58,7 +58,7 @@ export function updateAccountCredentialsPerformConsequence(
     removeExternalCredentials(dispatch, transaction.payload.removedCredIds);
 }
 
-async function ShieldedTransferConsequence(
+function ShieldedTransferConsequence(
     dispatch: Dispatch,
     transaction: TransferTransaction
 ) {

--- a/app/utils/TransactionStatusPoller.ts
+++ b/app/utils/TransactionStatusPoller.ts
@@ -32,6 +32,7 @@ import {
     insertExternalCredentials,
     removeExternalCredentials,
 } from '~/features/CredentialSlice';
+import { insert } from '~/database/DecryptedAmountsDao';
 
 /**
  * Given an UpdateAccountCredentials transaction, update the local state
@@ -58,7 +59,7 @@ export function updateAccountCredentialsPerformConsequence(
     removeExternalCredentials(dispatch, transaction.payload.removedCredIds);
 }
 
-function ShieldedTransferConsequence(
+async function ShieldedTransferConsequence(
     dispatch: Dispatch,
     transaction: TransferTransaction
 ) {
@@ -68,6 +69,12 @@ function ShieldedTransferConsequence(
     const { newSelfEncryptedAmount, remainingDecryptedAmount } = parse(
         transaction.encrypted
     );
+    if (transaction.decryptedAmount) {
+        await insert({
+            transactionHash: transaction.transactionHash,
+            amount: transaction.decryptedAmount,
+        });
+    }
     return updateShieldedBalance(
         dispatch,
         transaction.fromAddress,


### PR DESCRIPTION
## Purpose

Fix bug, which caused shielded balance to become locked after sending shielded transfer.

## Changes

Saves decrypted amount on finalization.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.