### PR TITLE
Also load pending transactions to an account

### DIFF
--- a/app/pages/Accounts/TransactionList/GtuDrop.tsx
+++ b/app/pages/Accounts/TransactionList/GtuDrop.tsx
@@ -12,6 +12,7 @@ import { displayTargetNet, getTargetNet } from '~/utils/ConfigHelper';
 import { getGTUSymbol, microGtuToGtu } from '~/utils/gtu';
 import { gtuDrop } from '~/utils/httpRequests';
 import { secondsSinceUnixEpoch } from '~/utils/timeHelpers';
+import { monitorTransactionStatus } from '~/utils/TransactionStatusPoller';
 import {
     TransactionKindString,
     TransactionStatus,
@@ -58,6 +59,7 @@ async function handleGtuDrop(
             subtotal: microGtuDropAmount,
         };
         await insertTransactions([gtuDropTransaction]);
+        monitorTransactionStatus(dispatch, gtuDropTransaction);
     } catch {
         setError(
             'An internal error occurred. Please try again. If the problem persists, please contact support.'

--- a/app/preload/database/transactionsDao.ts
+++ b/app/preload/database/transactionsDao.ts
@@ -50,7 +50,13 @@ async function getFilteredPendingTransactions(
             builder
                 .where({ fromAddress: address })
                 .andWhereBetween('blockTime', [fromTime, toTime])
+                .orWhere((orBuilder) =>
+                    orBuilder
+                        .where({ toAddress: address })
+                        .andWhereBetween('blockTime', [fromTime, toTime])
+                )
         )
+
         .orderBy('blockTime', 'desc');
 
     return queryTransactions;


### PR DESCRIPTION
## Purpose
Show pending transactions sent to an account. This includes transactions sent from another account in the desktop wallet and CCD drops.

## Changes
- Monitor the CCD drop transaction to ensure that it is cleaned up from the database when it is confirmed or rejected.
- When loading transactions for an account we now include any pending transactions _to_ that account.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.