### PR TITLE
Fix issue with wrong new transactions being fetched

### DIFF
--- a/app/features/TransactionSlice.ts
+++ b/app/features/TransactionSlice.ts
@@ -147,7 +147,9 @@ async function getNewTransactions(
 ): Promise<TransferTransaction[]> {
     // As the transactions in the state are in descending order on their id, the maxId
     // can be found as the first item with an id (if any exist).
-    const maxId = transactionsInState.find((t) => t.id !== undefined)?.id;
+    const maxId = transactionsInState.find(
+        (t) => t.id !== undefined && t.id !== null
+    )?.id;
 
     const transactions: IncomingTransaction[] = [];
     let full = true;


### PR DESCRIPTION
## Purpose
A pending transaction does not have an `id` as the `id` is given by the wallet proxy. The value is `null` and not `undefined` and therefore the logic for finding the maximum `id` in the current transaction state was erroneous. This resulted in the application fetching transactions without supplying the `from` input to the wallet proxy, which results in the wrong transactions being loaded. This change fixes that so that the correct `maxId` is found.

## Changes
- Also filter out any transactions with `transaction.id === null`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.