### PR TITLE
Only update accountInfoEntry on change

### DIFF
--- a/app/features/AccountSlice.ts
+++ b/app/features/AccountSlice.ts
@@ -488,10 +488,16 @@ export async function updateAccountInfoOfAddress(
  * Updates the given account's accountInfo, in the state, and check if there is updates to the account.
  * If given an address of an account that doesn't exist on chain, this throws an error.
  */
-export async function updateAccountInfo(account: Account, dispatch: Dispatch) {
+export async function updateAccountInfo(
+    account: Account,
+    currentInfo: AccountInfo | undefined,
+    dispatch: Dispatch
+) {
     const accountInfo = await getAccountInfoOfAddress(account.address);
-    await updateAccountFromAccountInfo(dispatch, account, accountInfo);
-    return updateAccountInfoEntry(dispatch, account.address, accountInfo);
+    if (stringify(accountInfo) !== stringify(currentInfo)) {
+        await updateAccountFromAccountInfo(dispatch, account, accountInfo);
+        updateAccountInfoEntry(dispatch, account.address, accountInfo);
+    }
 }
 
 // Add an account with pending status..


### PR DESCRIPTION
## Changes

updateAccountInfo now only performs updates, if there has been a change in the accountInfo.
updateAccountInfo effect in useAccountSync now uses timeouts to re-run the effect, instead of an interval (So it has access to the newest accountInfo)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
