### PR TITLE
Update default node

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -3,9 +3,9 @@ name: Build, lint and test
 on:
     # Triggers the workflow on push or pull request events but only for the main branch
     push:
-        branches: [main]
+        branches: [main, release**]
     pull_request:
-        branches: [main]
+        branches: [main, release**]
 
     # Allows us to run the workflow manually from the Actions tab
     workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Updated UI to reflect the rename of GTU to CCD, meaning anywhere tokens were referred to as GTU, it now says CCD. The GTU icon has also been replaced with the icon representing CCD.
 -   Datetimes are now selected with a date picker from a calendar.
 -   Finalized transactions are no longer stored in the local database, but are instead always fetched from the wallet proxy when needed.
+-   Updated the default node configuration to point to concordiumwalletnode.com.
 
 ### Fixed
 

--- a/app/database/migrations/20211214152503_set_new_default_node.ts
+++ b/app/database/migrations/20211214152503_set_new_default_node.ts
@@ -8,6 +8,12 @@ interface AddressPort {
     port: string;
 }
 
+const oldDefault: AddressPort = { address: '127.0.0.1', port: '10000' };
+const newDefault: AddressPort = {
+    address: 'concordiumwalletnode.com',
+    port: '10000',
+};
+
 /**
  * Migrates the node setting to a new default. The setting is only updated if the current
  * setting is set to the previous default value. This is to prevent migrating the setting
@@ -16,7 +22,7 @@ interface AddressPort {
 async function migrateDefaultNode(
     knex: Knex,
     previousDefault: AddressPort,
-    newDefault: AddressPort
+    updatedDefault: AddressPort
 ): Promise<number | void> {
     const currentNodeSetting = (
         await knex
@@ -29,7 +35,7 @@ async function migrateDefaultNode(
         addressAndPort.address === previousDefault.address &&
         addressAndPort.port === previousDefault.port
     ) {
-        const newDefaultSetting = JSON.stringify(newDefault);
+        const newDefaultSetting = JSON.stringify(updatedDefault);
         return knex
             .table(databaseNames.settingsTable)
             .update({ value: newDefaultSetting })
@@ -39,17 +45,9 @@ async function migrateDefaultNode(
 }
 
 export async function up(knex: Knex): Promise<number | void> {
-    return migrateDefaultNode(
-        knex,
-        { address: '127.0.0.1', port: '10000' },
-        { address: 'concordiumwalletnode.com', port: '10000' }
-    );
+    return migrateDefaultNode(knex, oldDefault, newDefault);
 }
 
 export async function down(knex: Knex): Promise<number | void> {
-    return migrateDefaultNode(
-        knex,
-        { address: 'concordiumwalletnode.com', port: '10000' },
-        { address: '127.0.0.1', port: '10000' }
-    );
+    return migrateDefaultNode(knex, newDefault, oldDefault);
 }

--- a/app/database/migrations/20211214152503_set_new_default_node.ts
+++ b/app/database/migrations/20211214152503_set_new_default_node.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 import databaseNames from '~/constants/databaseNames.json';
+import { getTargetNet, Net } from '~/utils/ConfigHelper';
 import { Setting } from '~/utils/types';
 import settingKeys from '../../constants/settingKeys.json';
 
@@ -45,9 +46,15 @@ async function migrateDefaultNode(
 }
 
 export async function up(knex: Knex): Promise<number | void> {
-    return migrateDefaultNode(knex, oldDefault, newDefault);
+    if (getTargetNet() === Net.Mainnet) {
+        return migrateDefaultNode(knex, oldDefault, newDefault);
+    }
+    return Promise.resolve();
 }
 
 export async function down(knex: Knex): Promise<number | void> {
-    return migrateDefaultNode(knex, newDefault, oldDefault);
+    if (getTargetNet() === Net.Mainnet) {
+        return migrateDefaultNode(knex, newDefault, oldDefault);
+    }
+    return Promise.resolve();
 }

--- a/app/database/migrations/20211214152503_set_new_default_node.ts
+++ b/app/database/migrations/20211214152503_set_new_default_node.ts
@@ -1,0 +1,55 @@
+import { Knex } from 'knex';
+import databaseNames from '~/constants/databaseNames.json';
+import { Setting } from '~/utils/types';
+import settingKeys from '../../constants/settingKeys.json';
+
+interface AddressPort {
+    address: string;
+    port: string;
+}
+
+/**
+ * Migrates the node setting to a new default. The setting is only updated if the current
+ * setting is set to the previous default value. This is to prevent migrating the setting
+ * for users who have already changed the setting to another node that they are using.
+ */
+async function migrateDefaultNode(
+    knex: Knex,
+    previousDefault: AddressPort,
+    newDefault: AddressPort
+): Promise<number | void> {
+    const currentNodeSetting = (
+        await knex
+            .table<Setting>(databaseNames.settingsTable)
+            .where({ name: settingKeys.nodeLocation })
+    )[0];
+    const addressAndPort: AddressPort = JSON.parse(currentNodeSetting.value);
+
+    if (
+        addressAndPort.address === previousDefault.address &&
+        addressAndPort.port === previousDefault.port
+    ) {
+        const newDefaultSetting = JSON.stringify(newDefault);
+        return knex
+            .table(databaseNames.settingsTable)
+            .update({ value: newDefaultSetting })
+            .where({ name: settingKeys.nodeLocation });
+    }
+    return Promise.resolve();
+}
+
+export async function up(knex: Knex): Promise<number | void> {
+    return migrateDefaultNode(
+        knex,
+        { address: '127.0.0.1', port: '10000' },
+        { address: 'concordiumwalletnode.com', port: '10000' }
+    );
+}
+
+export async function down(knex: Knex): Promise<number | void> {
+    return migrateDefaultNode(
+        knex,
+        { address: 'concordiumwalletnode.com', port: '10000' },
+        { address: '127.0.0.1', port: '10000' }
+    );
+}

--- a/app/pages/Home/SetNodeConnection/SetNodeConnection.tsx
+++ b/app/pages/Home/SetNodeConnection/SetNodeConnection.tsx
@@ -38,11 +38,10 @@ export default function SetNodeConnection() {
                             Most of the features in the Concordium Desktop
                             Wallet require an active connection to a node
                             participating in the Concordium blockchain. You can
-                            either connect to a publically available node, like
-                            the node provided on the right, or if you have your
-                            own node running you can connect to that instead.
-                            Make sure to input the correct IP address and port
-                            number.
+                            either connect to a publically available node, or if
+                            you have your own node running you can connect to
+                            that instead. Make sure to input the correct IP
+                            address and port number.
                         </p>
                         <p>
                             If you do not have a node running yet, you can read

--- a/app/pages/Home/SetNodeConnection/SetNodeConnection.tsx
+++ b/app/pages/Home/SetNodeConnection/SetNodeConnection.tsx
@@ -36,11 +36,13 @@ export default function SetNodeConnection() {
                     <Columns.Column className="textLeft">
                         <p className="mT0">
                             Most of the features in the Concordium Desktop
-                            Wallet requires an active connection to a node
-                            participating in the Concordium blockchain. If you
-                            already have your own node running, you can connect
-                            to it on the right. Make sure to input the correct
-                            IP address and port number.
+                            Wallet require an active connection to a node
+                            participating in the Concordium blockchain. You can
+                            either connect to a publically available node, like
+                            the node provided on the right, or if you have your
+                            own node running you can connect to that instead.
+                            Make sure to input the correct IP address and port
+                            number.
                         </p>
                         <p>
                             If you do not have a node running yet, you can read


### PR DESCRIPTION
## Purpose
Use Virtual Hive's public node as the default node in the desktop wallet. This should ease the use of the desktop wallet for users who do not wish to run their own node.

## Changes
- Migrated any default node settings from `127.0.0.1` to `concordiumwalletnode.com`. The idea is that users who have already changed their settings probably do not want it forcibly updated.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.