### PR TITLE
add process depencency, as webpack 5 doesn't polyfill.

### DIFF
--- a/configs/webpack.config.renderer.dev.js
+++ b/configs/webpack.config.renderer.dev.js
@@ -92,6 +92,9 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(false), {
         new webpack.LoaderOptionsPlugin({
             debug: true,
         }),
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+        }),
     ],
 
     node: {

--- a/configs/webpack.config.renderer.prod.js
+++ b/configs/webpack.config.renderer.prod.js
@@ -65,11 +65,13 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(true), {
             DEBUG_PROD: false,
             E2E_BUILD: false,
         }),
-
         new BundleAnalyzerPlugin({
             analyzerMode:
                 process.env.OPEN_ANALYZER === 'true' ? 'server' : 'disabled',
             openAnalyzer: process.env.OPEN_ANALYZER === 'true',
+        }),
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
         }),
     ],
 });

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "html2canvas": "^1.0.0-rc.7",
     "lodash.groupby": "^4.6.0",
     "noble-ed25519": "^1.0.3",
+    "process": "^0.11.10",
     "promise-worker": "^2.0.1",
     "qrcode.react": "^1.0.1",
     "react": "^16.13.1",


### PR DESCRIPTION
## Purpose
Fixes memo serialize and deserialize after webpack 5 upgrade 

## Changes

- add process polyfill

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.