### PR TITLE
Fix crash caused by empty date in identity attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+-   Fixed issue that caused the wallet to crash when inspecting identities with missing date attributes.
 -   Fixed identity issuance with dts.
 
 ## 1.3.0

--- a/app/utils/identityHelpers.ts
+++ b/app/utils/identityHelpers.ts
@@ -78,6 +78,14 @@ const parseDocType = (docType: DocumentType) => {
     }
 };
 
+const parseDate = (date: string) => {
+    try {
+        return formatDate(date);
+    } catch {
+        return 'N/A';
+    }
+};
+
 export function formatAttributeValue(
     key: AttributeKeyName,
     value: ChosenAttributes[typeof key]
@@ -87,7 +95,7 @@ export function formatAttributeValue(key: string, value: string): string {
         case 'idDocExpiresAt':
         case 'idDocIssuedAt':
         case 'dob':
-            return formatDate(value);
+            return parseDate(value);
         case 'sex':
             return parseGender(parseInt(value, 10));
         case 'idDocType':


### PR DESCRIPTION
## Purpose

Fix #210 

## Changes

If formatting date fails for an identity attribute, return "N/A" instead of throwing an error.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
