### PR TITLE
Windows sign during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "make-disclaimer": "yarn --prod true licenses generate-disclaimer > scripts/disclaimer.txt && node scripts/disclaimer.js && rimraf ./scripts/disclaimer.txt",
     "name": "echo $npm_package_productName-$TARGET_NET",
     "package": "yarn build && node ./scripts/build.js",
+    "package-win-no-sign": "set SIGNING=skip&& yarn build && node ./scripts/build.js",
     "package-mac-no-notarize": "export NOTARIZE=skip && yarn build && node ./scripts/build.js",
     "postinstall": "node internals/scripts/CheckNativeDep.js && electron-builder install-app-deps && yarn build-dll && opencollective-postinstall  && sh ./internals/scripts/build_protos.sh",
     "postlint-fix": "prettier --ignore-path .eslintignore --single-quote --write '**/*.{ts,tsx,js,jsx,json,html,yml}'",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const builder = require('electron-builder');
 
 const targetNet = process.env.TARGET_NET;
+const skipSigning = process.env.SIGNING === 'skip';
 
 let name;
 let productName;
@@ -28,6 +29,11 @@ builder.build({
             productName,
         },
         appId,
+        win: {
+            certificateSubjectName: skipSigning
+                ? undefined
+                : 'Concordium Software ApS',
+        },
     },
     publish: 'never',
 });


### PR DESCRIPTION
## Purpose

Allow signing desktop wallet during packaging on windows.

## Changes

Package on windows now tries to sign using our EV certificate.
added script "package-win-no-sign" to skip signing.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.