### PR TITLE
Fix incorrect mint formula, when value is zero

### DIFF
--- a/app/pages/multisig/updates/common/MintRateInput/MintRateInput.tsx
+++ b/app/pages/multisig/updates/common/MintRateInput/MintRateInput.tsx
@@ -106,7 +106,7 @@ export default function MintRateInput({
                 {paydaysPerYear.toLocaleString()}
             </span>{' '}
             - 1
-            {mantissa && exponent && (
+            {Boolean(mantissa) && Boolean(exponent) && (
                 <div className={styles.description}>
                     Chain value: {mantissa} · 10
                     <span className={styles.exponent}>-{exponent}</span>


### PR DESCRIPTION
## Purpose

In Time parameters (and mint distribution on P3), setting mint rate to 0 caused a 0 to be appended the formula.

Fix #253
