### PR TITLE
Fix mintRate overflowing out of the screen

### DIFF
--- a/app/pages/multisig/updates/common/MintRateInput/MintRateInput.tsx
+++ b/app/pages/multisig/updates/common/MintRateInput/MintRateInput.tsx
@@ -83,6 +83,7 @@ export default function MintRateInput({
                 onFocus={() => setAnnualFocused(true)}
                 onBlur={() => setAnnualFocused(false)}
                 disabled={disabled}
+                customFormatter={(v) => (v ? Number(v).toString() : '')}
             />{' '}
             ≈ (1 +{' '}
             <InlineNumber


### PR DESCRIPTION
## Purpose

Fix #252

## Changes

Mint rate yearly rate now uses js Number, to avoid large displays.
(So it show e-notation and approximations for values larger than MAX_SAFE_INTEGER)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
