### PR TITLE
Check delegation target is open for delegation

### DIFF
--- a/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
@@ -92,7 +92,6 @@ function PickDelegateAmount({
                     autoFocus
                     rules={{
                         required: 'Please specify amount to delegate',
-                        min: { value: 0, message: 'Value cannot be negative' },
                         validate: validDelegateAmount,
                     }}
                 />

--- a/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
@@ -24,7 +24,7 @@ import { validateDelegateAmount } from '~/utils/transactionHelpers';
 import { Account, AccountInfo, EqualRecord, Fraction } from '~/utils/types';
 import StakePendingChange from '~/components/StakePendingChange';
 import Loading from '~/cross-app-components/Loading';
-import { getPoolInfoLatest } from '~/node/nodeHelpers';
+import { getPoolStatusLatest } from '~/node/nodeHelpers';
 import { getCcdSymbol } from '~/utils/ccd';
 
 import styles from './DelegationPage.module.scss';
@@ -123,7 +123,7 @@ export default function DelegationAmountPage({
 }: Props) {
     const cooldownUntil = useCalcDelegatorCooldownUntil();
     const poolInfo = useAsyncMemo(
-        () => getPoolInfoLatest(target != null ? BigInt(target) : undefined),
+        () => getPoolStatusLatest(target != null ? BigInt(target) : undefined),
         noOp,
         [target]
     );

--- a/app/node/nodeHelpers.ts
+++ b/app/node/nodeHelpers.ts
@@ -11,7 +11,7 @@ import {
     getAnonymityRevokers,
     getPeerList,
     getTransactionStatus,
-    getPoolInfo,
+    getPoolStatus,
     getRewardStatus,
 } from './nodeRequests';
 import { PeerElement } from '../proto/concordium_p2p_rpc_pb';
@@ -72,11 +72,11 @@ export const applyLastBlockHash = <A extends any[], R>(
 export const getRewardStatusLatest = applyLastBlockHash(getRewardStatus);
 
 /**
- * Gets pool info for baker ID, or L-pool if parameter is left undefined.
+ * Gets pool status for baker ID, or L-pool if parameter is left undefined.
  *
  * @throws if no baker is found with supplied baker ID or if invalid block hash given.
  */
-export const getPoolInfoLatest = applyLastBlockHash(getPoolInfo);
+export const getPoolStatusLatest = applyLastBlockHash(getPoolStatus);
 
 export const fetchLastFinalizedIdentityProviders = applyLastBlockHash(
     getIdentityProviders

--- a/app/node/nodeRequests.ts
+++ b/app/node/nodeRequests.ts
@@ -67,10 +67,10 @@ export const getRewardStatus = throwIfUndefined(
     (blockHash) => `Unable to load reward status, on block: ${blockHash}`
 );
 
-export const getPoolInfo = throwIfUndefined(
-    window.grpc.getPoolInfo,
+export const getPoolStatus = throwIfUndefined(
+    window.grpc.getPoolStatus,
     (blockHash, target) =>
-        `Unable to get pool info for ${
+        `Unable to get pool status for ${
             target === undefined ? 'L-pool' : target
         }, on block: ${blockHash}`
 );

--- a/app/preload/grpc.ts
+++ b/app/preload/grpc.ts
@@ -102,7 +102,7 @@ const exposedMethods: GRPC = {
         return getConsensusStatusAndCryptographicParameters(address, port);
     },
     getRewardStatus: (blockHash: string) => client.getRewardStatus(blockHash),
-    getPoolInfo: (blockHash: string, bakerId?: BakerId) =>
+    getPoolStatus: (blockHash: string, bakerId?: BakerId) =>
         client.getPoolStatus(blockHash, bakerId),
 };
 

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -119,7 +119,7 @@ export type GRPC = {
     // We return a Uint8Array here, because PeerListResponse must be manually serialized/deserialized.
     getPeerList: (includeBootstrappers: boolean) => Promise<Uint8Array>;
     getRewardStatus: (blockHash: string) => Promise<RewardStatus | undefined>;
-    getPoolInfo: (
+    getPoolStatus: (
         blockHash: string,
         bakerId?: BakerId
     ) => Promise<PoolStatus | undefined>;

--- a/app/utils/transactionHelpers.ts
+++ b/app/utils/transactionHelpers.ts
@@ -652,6 +652,10 @@ export const validateDelegateAmount = (
 
     const amount = ccdToMicroCcd(value);
 
+    if (amount === 0n) {
+        return `Delegated amount must be positive`;
+    }
+
     if (max !== undefined && amount > max) {
         return `Cannot delegate more than (${displayAsCcd(max)})`;
     }


### PR DESCRIPTION
## Purpose

Fix #267, #269.

## Changes

- Check if target pool is open for delegation in `DelegationTargetPage`.
- Check that delegated amount is not 0 in `DelegationAmountPage`.
- Rename getPoolInfo to getPoolStatus to match Node-api and types.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
