### PR TITLE
Add missing pool information

### DIFF
--- a/app/components/BakerTransactions/BakerStakeSettings.tsx
+++ b/app/components/BakerTransactions/BakerStakeSettings.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import clsx from 'clsx';
 import { isBakerAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
-import {
-    useAccountInfo,
-    useCalcBakerStakeCooldownUntil,
-} from '~/utils/dataHooks';
+import { useAccountInfo } from '~/utils/dataHooks';
 import { Account, ClassName, EqualRecord, Fraction } from '~/utils/types';
 import AccountCard from '../AccountCard';
 import PickBakerStakeAmount from '../PickBakerStakeAmount';
 import PickBakerRestake from '../PickBakerRestake';
 import Form from '../Form';
 import { StakeSettings } from '~/utils/transactionFlows/configureBaker';
-import { getFormattedDateString } from '~/utils/timeHelpers';
 import StakePendingChange from '../StakePendingChange';
 
 const fieldNames: EqualRecord<StakeSettings> = {
@@ -27,7 +23,6 @@ interface Props extends ClassName {
     estimatedFee: Fraction;
     minimumStake: bigint;
     buttonClassName?: string;
-    showCooldown?: boolean;
     onSubmit(values: StakeSettings): void;
 }
 
@@ -41,14 +36,12 @@ export default function BakerStakeSettings({
     className,
     buttonClassName,
     onSubmit,
-    showCooldown = false,
 }: Props) {
     const accountInfo = useAccountInfo(account.address);
     const pendingChange =
         accountInfo !== undefined && isBakerAccount(accountInfo)
             ? accountInfo?.accountBaker.pendingChange
             : undefined;
-    const cooldownUntil = useCalcBakerStakeCooldownUntil();
 
     return (
         <Form<StakeSettings>
@@ -56,7 +49,7 @@ export default function BakerStakeSettings({
             className={clsx('flexColumn flexChildFill', className)}
         >
             <div className="flexChildFill">
-                {showCooldown || (
+                {existingValues !== undefined || (
                     <p className="mT0">
                         To register as a baker, you must choose an amount to
                         stake on the account. The staked amount will be part of
@@ -64,24 +57,15 @@ export default function BakerStakeSettings({
                         for transactions.
                     </p>
                 )}
-                {showCooldown && pendingChange === undefined && (
-                    <p className="mT0">
-                        Enter your new desired amount to stake. If you raise the
-                        stake it will take effect after two epochs, and if you
-                        lower the stake it will take effect after the grace
-                        period.
-                        {cooldownUntil && (
-                            <>
-                                <br />
-                                <br />
-                                This grace period will last until
-                                <span className="block bodyEmphasized  mV10">
-                                    {getFormattedDateString(cooldownUntil)}
-                                </span>
-                            </>
-                        )}
-                    </p>
-                )}
+                {existingValues !== undefined &&
+                    pendingChange === undefined && (
+                        <p className="mT0">
+                            Enter your new desired amount to stake. If you raise
+                            the stake it will take effect after two epochs, and
+                            if you lower the stake it will take effect after the
+                            grace period.
+                        </p>
+                    )}
                 {pendingChange !== undefined && (
                     <div className="mV10 body2">
                         Cannot update baker stake at this time:

--- a/app/components/Transfers/configureBaker/UpdateBakerStakePage.tsx
+++ b/app/components/Transfers/configureBaker/UpdateBakerStakePage.tsx
@@ -62,7 +62,6 @@ function UpdateBakerStakePage({
             buttonClassName={styles.continue}
             showAccountCard={isMultiSig}
             existingValues={existing}
-            showCooldown
         />
     );
 }

--- a/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
@@ -3,6 +3,7 @@ import { useForm, useFormContext, Validate } from 'react-hook-form';
 import { Redirect } from 'react-router';
 import clsx from 'clsx';
 import { isDelegatorAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
+import { PoolStatusType } from '@concordium/node-sdk/lib/src/types';
 import { BakerPoolStatus } from '@concordium/node-sdk';
 import AccountCard from '~/components/AccountCard';
 import Form from '~/components/Form';
@@ -25,7 +26,8 @@ import { Account, AccountInfo, EqualRecord, Fraction } from '~/utils/types';
 import StakePendingChange from '~/components/StakePendingChange';
 import Loading from '~/cross-app-components/Loading';
 import { getPoolStatusLatest } from '~/node/nodeHelpers';
-import { getCcdSymbol } from '~/utils/ccd';
+import { displayAsCcd, getCcdSymbol } from '~/utils/ccd';
+import SidedRow from '~/components/SidedRow';
 
 import styles from './DelegationPage.module.scss';
 
@@ -51,8 +53,12 @@ function PickDelegateAmount({
     max,
     hasPendingChange,
 }: PickDelegateAmountProps) {
+    const cooldownUntil = useCalcDelegatorCooldownUntil();
     const form = useFormContext<SubState>();
     const { errors } = form;
+    const amount = form.watch(fieldNames.amount);
+    const showCooldown =
+        existing !== undefined && form.formState.isValid && amount < existing;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const validDelegateAmount: Validate = useCallback(
@@ -83,7 +89,11 @@ function PickDelegateAmount({
             )}
             <Label>Amount</Label>
             <div className="h1 mV5">
-                <span className={clsx(hasPendingChange && 'textFaded')}>
+                <span
+                    className={clsx(
+                        hasPendingChange ? 'textFaded' : 'textBlue'
+                    )}
+                >
                     {getCcdSymbol()}
                 </span>
                 <Form.CcdInput
@@ -97,6 +107,14 @@ function PickDelegateAmount({
                 />
             </div>
             <ErrorMessage>{errors.amount?.message}</ErrorMessage>
+            {cooldownUntil && showCooldown && (
+                <div className="textFaded">
+                    Will take effect at
+                    <span className="block bodyEmphasized mT5">
+                        {getFormattedDateString(cooldownUntil)}
+                    </span>
+                </div>
+            )}
         </div>
     );
 }
@@ -120,7 +138,6 @@ export default function DelegationAmountPage({
     exchangeRate,
     baseRoute,
 }: Props) {
-    const cooldownUntil = useCalcDelegatorCooldownUntil();
     const poolInfo = useAsyncMemo(
         () => getPoolStatusLatest(target != null ? BigInt(target) : undefined),
         noOp,
@@ -195,26 +212,32 @@ export default function DelegationAmountPage({
                         the stake it will take effect after two epochs, and if
                         you lower the stake it will take effect after the grace
                         period.
-                        {cooldownUntil && (
-                            <>
-                                <br />
-                                <br />
-                                This grace period will last until
-                                <span className="block bodyEmphasized mV10">
-                                    {getFormattedDateString(cooldownUntil)}
-                                </span>
-                            </>
-                        )}
                     </p>
                 )}
                 {pendingChange !== undefined && (
-                    <div className="mV10 body2">
+                    <div className="mB10 body2">
                         Cannot update delegated amount at this time:
                         <div className="bodyEmphasized textError mV10">
                             <StakePendingChange pending={pendingChange} />
                         </div>
                         It will be possible to proceed after this time has
                         passed.
+                    </div>
+                )}
+                {poolInfo.poolType === PoolStatusType.BakerPool && (
+                    <div className="body2 mV30">
+                        <Label className="mB5">Target pool status</Label>
+                        <SidedRow
+                            left="Current pool:"
+                            right={`${displayAsCcd(poolInfo.delegatedCapital)}`}
+                        />
+                        <SidedRow
+                            className="mT5"
+                            left="Pool limit:"
+                            right={`${displayAsCcd(
+                                poolInfo.delegatedCapitalCap
+                            )}`}
+                        />
                     </div>
                 )}
                 {showAccountCard && (

--- a/app/pages/Accounts/AccountDetailsPage/Baking/OldBakerFlows/UpdateBakerStake.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/Baking/OldBakerFlows/UpdateBakerStake.tsx
@@ -14,10 +14,7 @@ import {
     chosenAccountSelector,
 } from '~/features/AccountSlice';
 import { ChainData, ensureChainData } from '~/utils/withChainData';
-import {
-    useCalcBakerStakeCooldownUntil,
-    useTransactionCostEstimate,
-} from '~/utils/dataHooks';
+import { useTransactionCostEstimate } from '~/utils/dataHooks';
 import { stringify } from '~/utils/JSONHelper';
 import { createUpdateBakerStakeTransaction } from '~/utils/transactionHelpers';
 import {
@@ -29,7 +26,6 @@ import {
 import { SubmitTransactionLocationState } from '../../../SubmitTransaction/SubmitTransaction';
 import { multiplyFraction } from '~/utils/basicHelpers';
 import StakePendingChange from '~/components/StakePendingChange';
-import { getFormattedDateString } from '~/utils/timeHelpers';
 import { isMultiSig } from '~/utils/accountHelpers';
 import { createTransferWithAccountRoute } from '~/utils/accountRouterHelpers';
 import ensureExchangeRateAndNonce, {
@@ -66,7 +62,6 @@ const UpdateBakerStakeForm = ensureExchangeRateAndNonce(
             exchangeRate,
             account?.signatureThreshold
         );
-        const cooldownUntil = useCalcBakerStakeCooldownUntil();
 
         const submit = useCallback(
             ({ stake }: FormModel) => {
@@ -153,16 +148,6 @@ const UpdateBakerStakeForm = ensureExchangeRateAndNonce(
                     Enter your new desired amount to stake. If you raise the
                     stake it will take effect after two epochs, and if you lower
                     the stake it will take effect after the grace period.
-                    {cooldownUntil && (
-                        <>
-                            <br />
-                            <br />
-                            This grace period will last until
-                            <div className="bodyEmphasized  mV10">
-                                {getFormattedDateString(cooldownUntil)}
-                            </div>
-                        </>
-                    )}
                 </div>
                 <PickBakerStakeAmount
                     header="New stake:"


### PR DESCRIPTION
## Purpose

Fixes #271 

## Changes

- Shows pool info for specific baker target on when specifying delegation amount
- Only show staking cooldown if staked amount is being decreased

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
