### PR TITLE
Display transaction events in transaction view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Support for chain updates added in protocol version 4 (Cooldown, Pool and Time parameters).
 -   Support for chain updates that are changed in protocol version 4 (Mint distribution and level2 key updates).
 -   Support for new reward types introduced with delegation in transaction list and account export.
+-   Display transaction events when a single transaction is selected (Transaction view).
 
 ### Changed
 

--- a/app/pages/Accounts/TransactionView/TransactionView.module.scss
+++ b/app/pages/Accounts/TransactionView/TransactionView.module.scss
@@ -68,19 +68,17 @@
 
 .eventsButtonOpen,
 .eventsButtonClosed {
-    padding: 0;
+    position: absolute;
+    right: 14px;
+    padding-right: 0;
 }
 
 .eventsButtonOpen {
-    svg {
-        transform: rotate(90deg);
-    }
+    transform: rotate(-90deg);
 }
 
 .eventsButtonClosed {
-    svg {
-        transform: rotate(-90deg);
-    }
+    transform: rotate(90deg);
 }
 
 .eventsTextClosed,

--- a/app/pages/Accounts/TransactionView/TransactionView.module.scss
+++ b/app/pages/Accounts/TransactionView/TransactionView.module.scss
@@ -65,3 +65,35 @@
     top: 9px;
     right: 12px;
 }
+
+.eventsButtonOpen,
+.eventsButtonClosed {
+    padding: 0;
+}
+
+.eventsButtonOpen {
+    svg {
+        transform: rotate(90deg);
+    }
+}
+
+.eventsButtonClosed {
+    svg {
+        transform: rotate(-90deg);
+    }
+}
+
+.eventsTextClosed,
+.event {
+    font-size: $font-size-body4;
+    margin-bottom: 5px;
+    margin-right: 35px;
+    margin-top: 0;
+}
+
+.eventsTextClosed {
+    white-space: nowrap;
+    height: 1.3em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/app/pages/Accounts/TransactionView/TransactionView.tsx
+++ b/app/pages/Accounts/TransactionView/TransactionView.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
+import BackArrow from '@resources/svg/back-arrow.svg';
 import TransactionListElement from '../TransactionList/TransactionListElement';
 import {
     TransferTransactionWithNames,
@@ -12,8 +13,10 @@ import SidedRow from '~/components/SidedRow';
 import CopyButton from '~/components/CopyButton';
 import { rejectReasonToDisplayText } from '~/utils/node/RejectReasonHelper';
 import { transactionsSelector } from '~/features/TransactionSlice';
-import styles from './TransactionView.module.scss';
 import CloseButton from '~/cross-app-components/CloseButton';
+import IconButton from '~/cross-app-components/IconButton';
+
+import styles from './TransactionView.module.scss';
 
 interface Props {
     transaction: TransferTransactionWithNames;
@@ -49,6 +52,47 @@ function CopiableListElement({
             }
             right={<CopyButton className={styles.copyButton} value={value} />}
         />
+    );
+}
+
+interface TransactionEventsProps {
+    events?: string[];
+}
+
+function TransactionEvents({ events }: TransactionEventsProps) {
+    const [open, setOpen] = useState(false);
+
+    if (!events || events.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className={clsx(styles.listElement, 'flexColumn')}>
+            <div className="flex justifySpaceBetween">
+                <p className={styles.copiableListElementTitle}>Events</p>
+                <IconButton
+                    type="button"
+                    title="close"
+                    className={
+                        open
+                            ? styles.eventsButtonClosed
+                            : styles.eventsButtonOpen
+                    }
+                    onClick={() => setOpen(!open)}
+                >
+                    <BackArrow width="20" />
+                </IconButton>
+            </div>
+            {open ? (
+                events.map((event: string) => (
+                    <p key={event} className={styles.event}>
+                        {event}
+                    </p>
+                ))
+            ) : (
+                <p className={styles.eventsTextClosed}>{events[0]}</p>
+            )}
+        </div>
     );
 }
 
@@ -123,6 +167,7 @@ function TransactionView({ transaction, onClose, setTransaction }: Props) {
                 title="Block hash"
                 value={transaction.blockHash || 'Awaiting finalization'}
             />
+            <TransactionEvents events={transaction.events} />
         </div>
     );
 }

--- a/app/utils/TransactionConverters.ts
+++ b/app/utils/TransactionConverters.ts
@@ -144,6 +144,7 @@ export function convertIncomingTransaction(
         toAddress,
         rejectReason: transaction.details.rawRejectReason?.tag,
         status,
+        events: transaction.details.events,
         memo: dataBlob,
     };
 }

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -605,6 +605,7 @@ export interface TransferTransaction {
     rejectReason?: RejectReason | string;
     decryptedAmount?: string;
     memo?: string;
+    events?: string[];
 }
 
 export interface TransferTransactionWithNames extends TransferTransaction {


### PR DESCRIPTION
## Purpose

Fix #248, both the new configure and reward transactions have information hidden in the events 

## Changes

Display transaction events in transaction view.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
