### PR TITLE
285 notify user of closing baker pool

### DIFF
--- a/app/components/ClosingBakerPoolNotification.tsx
+++ b/app/components/ClosingBakerPoolNotification.tsx
@@ -25,7 +25,9 @@ export default function ClosingBakerPoolNotification({
             <div className="flex alignCenter">
                 The target pool of the following account will close soon.
             </div>
-            <div className="flex alignCenter mT10">{accountName}</div>
+            <div className="flex alignCenter mT10">
+                <b>{accountName}</b>
+            </div>
             <div className="inlineFlexColumn mT20">
                 <Button className="mT10" size="tiny" onClick={onClose}>
                     Remind me

--- a/app/components/ClosingBakerPoolNotification.tsx
+++ b/app/components/ClosingBakerPoolNotification.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Notification from './Notification';
+import { NotificationLevel } from '~/features/NotificationSlice';
+import Button from '~/cross-app-components/Button';
+
+interface Props {
+    onClose(): void;
+    accountName: string;
+}
+
+/**
+ * A notification to be shown when an account is delegating to a baker pool
+ * that is going to close in the near future.
+ */
+export default function ClosingBakerPoolNotification({
+    onClose,
+    accountName,
+}: Props) {
+    return (
+        <Notification
+            className="flexColumn alignCenter"
+            level={NotificationLevel.ClosingBakerPool}
+            onCloseClick={onClose}
+        >
+            <div className="flex alignCenter">
+                The target pool of the following account will close soon.
+            </div>
+            <div className="flex alignCenter mT10">{accountName}</div>
+            <div className="inlineFlexColumn mT20">
+                <Button className="mT10" size="tiny" onClick={onClose}>
+                    Remind me
+                </Button>
+            </div>
+        </Notification>
+    );
+}

--- a/app/components/ClosingBakerPoolNotification.tsx
+++ b/app/components/ClosingBakerPoolNotification.tsx
@@ -25,10 +25,10 @@ export default function ClosingBakerPoolNotification({
             <div className="flex alignCenter">
                 The target pool of the following account will close soon.
             </div>
-            <div className="flex alignCenter mT10">
+            <div className="flex alignCenter mT10 textBreakAll">
                 <b>{accountName}</b>
             </div>
-            <div className="inlineFlexColumn mT20">
+            <div className="inlineFlexColumn mT10">
                 <Button className="mT10" size="tiny" onClick={onClose}>
                     Remind me
                 </Button>

--- a/app/components/Notification/Notification.module.scss
+++ b/app/components/Notification/Notification.module.scss
@@ -8,6 +8,7 @@
     background-color: $color-white;
     width: 100%;
     height: 160px;
+    z-index: 1000;
 
     & + & {
         margin-top: 10px;

--- a/app/features/NotificationSlice.ts
+++ b/app/features/NotificationSlice.ts
@@ -5,6 +5,7 @@ export enum NotificationLevel {
     Error = 'error',
     ManualUpdate = 'manual-update',
     AutoUpdate = 'auto-update',
+    ClosingBakerPool = 'closing-baker-pool',
 }
 
 let nextId = 0;
@@ -18,16 +19,27 @@ interface UpdateNotification extends NotificationBase {
     version: string;
 }
 
+export interface ClosingBakerNotification extends NotificationBase {
+    level: NotificationLevel.ClosingBakerPool;
+    accountName: string;
+}
+
 export interface Notification extends NotificationBase {
     level: Exclude<
         NotificationLevel,
-        NotificationLevel.ManualUpdate | NotificationLevel.AutoUpdate
+        | NotificationLevel.ManualUpdate
+        | NotificationLevel.AutoUpdate
+        | NotificationLevel.ClosingBakerPool
     >;
     message: string;
 }
 
 interface NotificationSliceState {
-    notifications: (UpdateNotification | Notification)[];
+    notifications: (
+        | UpdateNotification
+        | Notification
+        | ClosingBakerNotification
+    )[];
 }
 
 const { actions, reducer } = createSlice({
@@ -38,7 +50,9 @@ const { actions, reducer } = createSlice({
     reducers: {
         pushNotification(
             state,
-            action: PayloadAction<Notification | UpdateNotification>
+            action: PayloadAction<
+                Notification | UpdateNotification | ClosingBakerNotification
+            >
         ) {
             state.notifications.push({ ...action.payload });
         },
@@ -69,6 +83,20 @@ export function triggerUpdateNotification(
         })
     );
 
+    nextId += 1;
+}
+
+export function triggerClosingBakerPoolNotification(
+    dispatch: Dispatch,
+    accountName: string
+) {
+    dispatch(
+        actions.pushNotification({
+            level: NotificationLevel.ClosingBakerPool,
+            id: nextId,
+            accountName,
+        })
+    );
     nextId += 1;
 }
 

--- a/app/pages/Accounts/AccountDetailsPage/StakingDetails/StakingDetails.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/StakingDetails/StakingDetails.tsx
@@ -16,6 +16,7 @@ import { useLastFinalizedBlockSummary } from '~/utils/dataHooks';
 import { toFixed } from '~/utils/numberStringHelpers';
 import { hasDelegationProtocol } from '~/utils/protocolVersion';
 import {
+    dateFromBakerPoolPendingChange,
     dateFromStakePendingChange,
     getFormattedDateString,
 } from '~/utils/timeHelpers';
@@ -209,6 +210,18 @@ export default function StakingDetails({ details }: Props) {
               )
             : undefined;
 
+    const pendingClosingBakerDate =
+        poolStatus !== undefined &&
+        poolStatus.bakerStakePendingChange.pendingChangeType ===
+            BakerPoolPendingChangeType.RemovePool
+            ? dateFromBakerPoolPendingChange(
+                  poolStatus.bakerStakePendingChange,
+                  cs,
+                  rs,
+                  bs?.updates.chainParameters
+              )
+            : undefined;
+
     return (
         <Card className={styles.root} dark>
             <header className={styles.header}>
@@ -248,27 +261,22 @@ export default function StakingDetails({ details }: Props) {
                         )}
                     </div>
                 )}
-            {poolStatus !== undefined &&
-                poolStatus.bakerStakePendingChange.pendingChangeType ===
-                    BakerPoolPendingChangeType.RemovePool && (
-                    <div className={styles.pending}>
-                        <div className="textWhite mB20">
-                            The following changes will take effect on
-                            <br />
-                            {getFormattedDateString(
-                                poolStatus.bakerStakePendingChange.effectiveTime
-                            )}
-                        </div>
-                        <span className="mB20">
-                            Your target pool is closing soon. If you do not
-                            actively change the target pool, then your account
-                            will keep earning rewards as a passive delegator
-                            after your target pool has closed. You can, however,
-                            already change your target pool now, if you would
-                            rather do that.
-                        </span>
+            {pendingClosingBakerDate !== undefined && (
+                <div className={styles.pending}>
+                    <div className="textWhite mB20">
+                        The following changes will take effect on
+                        <br />
+                        {getFormattedDateString(pendingClosingBakerDate)}
                     </div>
-                )}
+                    <span className="mB20">
+                        Your target pool is closing soon. If you do not actively
+                        change the target pool, then your account will keep
+                        earning rewards as a passive delegator after your target
+                        pool has closed. You can, however, already change your
+                        target pool now, if you would rather do that.
+                    </span>
+                </div>
+            )}
         </Card>
     );
 }

--- a/app/pages/Home/SelectPassword/SelectPassword.tsx
+++ b/app/pages/Home/SelectPassword/SelectPassword.tsx
@@ -4,7 +4,7 @@ import { SubmitHandler, useForm, Validate } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import Form from '~/components/Form';
 import PageLayout from '~/components/PageLayout';
-import initApplication from '~/utils/initialize';
+import initApplication from '~/utils/init/initialize';
 import { passwordValidators } from '~/utils/passwordHelpers';
 import routes from '~/constants/routes.json';
 import homeStyles from '../Home.module.scss';

--- a/app/pages/Home/Unlock/Unlock.tsx
+++ b/app/pages/Home/Unlock/Unlock.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { FieldValues, useForm } from 'react-hook-form';
 import Card from '~/cross-app-components/Card';
-import initApplication from '~/utils/initialize';
+import initApplication from '~/utils/init/initialize';
 import routes from '~/constants/routes.json';
 import Form from '~/components/Form';
 import { useUpdateEffect } from '~/utils/hooks';

--- a/app/shell/Notifications/Notifications.tsx
+++ b/app/shell/Notifications/Notifications.tsx
@@ -12,6 +12,7 @@ import {
 import { RootState } from '~/store/store';
 
 import styles from './Notifications.module.scss';
+import ClosingBakerPoolNotification from '~/components/ClosingBakerPoolNotification';
 
 export default function Notifications() {
     const { notifications } = useSelector((s: RootState) => s.notification);
@@ -43,6 +44,14 @@ export default function Notifications() {
                                     key={n.id}
                                     onClose={() => handleClose(n.id)}
                                     version={n.version}
+                                />
+                            );
+                        case NotificationLevel.ClosingBakerPool:
+                            return (
+                                <ClosingBakerPoolNotification
+                                    key={n.id}
+                                    onClose={() => handleClose(n.id)}
+                                    accountName={n.accountName}
                                 />
                             );
                         default:

--- a/app/styles/elements/_typography.scss
+++ b/app/styles/elements/_typography.scss
@@ -130,3 +130,7 @@ b {
 .textNoWrap {
     white-space: nowrap;
 }
+
+.textBreakAll {
+    word-break: break-all;
+}

--- a/app/utils/init/closingBakerPoolChecker.ts
+++ b/app/utils/init/closingBakerPoolChecker.ts
@@ -1,0 +1,59 @@
+import { isDelegatorAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
+import {
+    BakerPoolPendingChangeType,
+    DelegationTargetType,
+    PoolStatusType,
+} from '@concordium/node-sdk/lib/src/types';
+import { Account, AccountStatus, Dispatch } from '../types';
+import { findAccounts } from '~/database/AccountDao';
+import {
+    getAccountInfoOfAddress,
+    getPoolStatusLatest,
+} from '~/node/nodeHelpers';
+import { triggerClosingBakerPoolNotification } from '~/features/NotificationSlice';
+
+/**
+ * Finds all accounts from the database that are currently delegating to a closing baker pool.
+ */
+async function findAccountsDelegatingToClosingBakerPools() {
+    const accounts = await findAccounts({ status: AccountStatus.Confirmed });
+    const accountsDelegatingToClosingPool: Account[] = [];
+
+    for (const account of accounts) {
+        const accountInfo = await getAccountInfoOfAddress(account.address);
+        if (
+            isDelegatorAccount(accountInfo) &&
+            accountInfo.accountDelegation.delegationTarget.delegateType ===
+                DelegationTargetType.Baker
+        ) {
+            const { bakerId } = accountInfo.accountDelegation.delegationTarget;
+            const poolStatus = await getPoolStatusLatest(bakerId);
+
+            // TODO: This is always true (we checked that the account is delegating to a baker),
+            // but our typing is not good enough here, so we need yet another guard.
+            if (poolStatus.poolType === PoolStatusType.BakerPool) {
+                if (
+                    poolStatus.bakerStakePendingChange.pendingChangeType ===
+                    BakerPoolPendingChangeType.RemovePool
+                ) {
+                    accountsDelegatingToClosingPool.push(account);
+                }
+            }
+        }
+    }
+
+    return accountsDelegatingToClosingPool;
+}
+
+/**
+ * Creates a notification for each account that is currently delegating to a
+ * closing baker pool.
+ * @param dispatch redux action dispatcher
+ */
+export default async function checkForClosingBakerPools(dispatch: Dispatch) {
+    const accountsDelegatingToClosingPool = await findAccountsDelegatingToClosingBakerPools();
+
+    for (const account of accountsDelegatingToClosingPool) {
+        triggerClosingBakerPoolNotification(dispatch, account.name);
+    }
+}

--- a/app/utils/init/initialize.ts
+++ b/app/utils/init/initialize.ts
@@ -9,12 +9,13 @@ import {
 import { loadIdentities } from '~/features/IdentitySlice';
 import { loadProposals } from '~/features/MultiSignatureSlice';
 import { findSetting, updateSettings } from '~/features/SettingsSlice';
-import listenForIdentityStatus from './IdentityStatusPoller';
-import startClient from '../node/nodeConnector';
-import { Dispatch } from './types';
-import settingKeys from '../constants/settingKeys.json';
+import listenForIdentityStatus from '../IdentityStatusPoller';
+import startClient from '../../node/nodeConnector';
+import { Dispatch } from '../types';
+import settingKeys from '../../constants/settingKeys.json';
 import { unlock } from '~/features/MiscSlice';
-import { throwLoggedError } from './basicHelpers';
+import { throwLoggedError } from '../basicHelpers';
+import checkForClosingBakerPools from './closingBakerPoolChecker';
 
 /**
  * Loads settings from the database into the store.
@@ -35,7 +36,8 @@ async function loadSettingsIntoStore(dispatch: Dispatch) {
 /**
  * Initializes the application by loading data from the database into the
  * state.
- * Also starts listening for the status of identities.
+ * Also starts listening for the status of identities and ensures notifications
+ * are created for accounts delegating to a closing baker pool.
  */
 export default async function initApplication(dispatch: Dispatch) {
     await loadSettingsIntoStore(dispatch);
@@ -52,4 +54,9 @@ export default async function initApplication(dispatch: Dispatch) {
 
     dispatch(unlock());
     listenForIdentityStatus(dispatch);
+    checkForClosingBakerPools(dispatch).catch((e) =>
+        window.log.error('Error while checking for closing baker pools', {
+            error: e,
+        })
+    );
 }


### PR DESCRIPTION
## Purpose
Notify users (at startup) if they are currently delegating to a baker pool that is shutting down.

## Changes
- At startup the application checks whether any delegating account is delegating to a pool that is in the process of closing. A notification is created for each account where this is the case.
- The delegation view now shows if the target pool is shutting down and includes when it will happen.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.