### PR TITLE
Better types for getPoolStatus

### DIFF
--- a/app/components/PickBakerStakeAmount.tsx
+++ b/app/components/PickBakerStakeAmount.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import React, { useCallback } from 'react';
 import { useFormContext, Validate } from 'react-hook-form';
-import { PoolStatusType } from '@concordium/node-sdk/lib/src/types';
 import { isRewardStatusV1 } from '@concordium/node-sdk/lib/src/rewardStatusHelpers';
 import { isBakerAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
 import { collapseFraction, noOp } from '~/utils/basicHelpers';
@@ -53,9 +52,7 @@ function useCapitalBoundCheck(
                 const status = await getPoolStatusLatest(
                     accountInfo.accountIndex
                 );
-                if (status.poolType === PoolStatusType.BakerPool) {
-                    return status;
-                }
+                return status;
             }
             return Promise.resolve(undefined);
         },

--- a/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationAmountPage.tsx
@@ -3,7 +3,6 @@ import { useForm, useFormContext, Validate } from 'react-hook-form';
 import { Redirect } from 'react-router';
 import clsx from 'clsx';
 import { isDelegatorAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
-import { PoolStatusType } from '@concordium/node-sdk/lib/src/types';
 import { BakerPoolStatus } from '@concordium/node-sdk';
 import AccountCard from '~/components/AccountCard';
 import Form from '~/components/Form';
@@ -155,7 +154,10 @@ export default function DelegationAmountPage({
     baseRoute,
 }: Props) {
     const poolInfo = useAsyncMemo(
-        () => getPoolStatusLatest(target != null ? BigInt(target) : undefined),
+        () =>
+            target != null
+                ? getPoolStatusLatest(BigInt(target))
+                : Promise.resolve(undefined),
         noOp,
         [target]
     );
@@ -242,22 +244,18 @@ export default function DelegationAmountPage({
                         passed.
                     </div>
                 )}
-                {poolInfo.poolType === PoolStatusType.BakerPool && (
-                    <div className="body2 mV30">
-                        <Label className="mB5">Target pool status</Label>
-                        <SidedRow
-                            left="Current pool:"
-                            right={`${displayAsCcd(poolInfo.delegatedCapital)}`}
-                        />
-                        <SidedRow
-                            className="mT5"
-                            left="Pool limit:"
-                            right={`${displayAsCcd(
-                                poolInfo.delegatedCapitalCap
-                            )}`}
-                        />
-                    </div>
-                )}
+                <div className="body2 mV30">
+                    <Label className="mB5">Target pool status</Label>
+                    <SidedRow
+                        left="Current pool:"
+                        right={`${displayAsCcd(poolInfo.delegatedCapital)}`}
+                    />
+                    <SidedRow
+                        className="mT5"
+                        left="Pool limit:"
+                        right={`${displayAsCcd(poolInfo.delegatedCapitalCap)}`}
+                    />
+                </div>
                 {showAccountCard && (
                     <AccountCard account={account} accountInfo={accountInfo} />
                 )}

--- a/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { useForm, Validate } from 'react-hook-form';
-import {
-    OpenStatusText,
-    PoolStatusType,
-} from '@concordium/node-sdk/lib/src/types';
+import { OpenStatusText } from '@concordium/node-sdk/lib/src/types';
 import { isDelegatorAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
 import Form from '~/components/Form';
 import { validBigInt } from '~/components/Form/util/validation';
@@ -59,12 +56,8 @@ export default function DelegationTargetPage({
 
         try {
             const bakerId = BigInt(value);
-            const poolStatus = await getPoolStatusLatest(bakerId); // Throws if response is undefined.
-
-            // TODO Fix getPoolStatusLatest type so the type checker knows poolStatus is BakerPoolStatus here
-            if (poolStatus.poolType !== PoolStatusType.BakerPool) {
-                return true;
-            }
+            // Throws if response is undefined.
+            const poolStatus = await getPoolStatusLatest(bakerId);
 
             if (poolStatus.poolInfo.openStatus !== OpenStatusText.OpenForAll) {
                 return 'Targeted baker does not allow new delegators';

--- a/app/node/nodeHelpers.ts
+++ b/app/node/nodeHelpers.ts
@@ -72,7 +72,7 @@ export const applyLastBlockHash = <A extends any[], R>(
 export const getRewardStatusLatest = applyLastBlockHash(getRewardStatus);
 
 /**
- * Gets pool status for baker ID, or for passive delegation if parameter is left undefined.
+ * Gets pool status for baker ID.
  *
  * @throws if no baker is found with supplied baker ID or if invalid block hash given.
  */

--- a/app/pages/Accounts/AccountDetailsPage/StakingDetails/StakingDetails.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/StakingDetails/StakingDetails.tsx
@@ -4,7 +4,6 @@ import {
     AccountDelegationDetails,
     BakerPoolPendingChangeType,
     DelegationTargetType,
-    PoolStatusType,
 } from '@concordium/node-sdk/lib/src/types';
 import { isReduceStakePendingChange } from '@concordium/node-sdk/lib/src/accountHelpers';
 import React, { PropsWithChildren } from 'react';
@@ -185,12 +184,7 @@ export default function StakingDetails({ details }: Props) {
                     cs.lastFinalizedBlock,
                     details.delegationTarget.bakerId
                 );
-                // TODO: When getPoolStatus is better typed this is not necessary anymore.
-                if (status.poolType === PoolStatusType.BakerPool) {
-                    return status;
-                }
-                // This line should never be reached, and can be cleaned up when getPoolStatus has better types.
-                return undefined;
+                return status;
             }
             return undefined;
         },

--- a/app/preload/grpc.ts
+++ b/app/preload/grpc.ts
@@ -102,7 +102,7 @@ const exposedMethods: GRPC = {
         return getConsensusStatusAndCryptographicParameters(address, port);
     },
     getRewardStatus: (blockHash: string) => client.getRewardStatus(blockHash),
-    getPoolStatus: (blockHash: string, bakerId?: BakerId) =>
+    getPoolStatus: (blockHash: string, bakerId: BakerId) =>
         client.getPoolStatus(blockHash, bakerId),
 };
 

--- a/app/preload/preloadTypes.ts
+++ b/app/preload/preloadTypes.ts
@@ -1,11 +1,11 @@
 import {
     AccountInfo,
     BakerId,
+    BakerPoolStatus,
     BlockSummary,
     ConsensusStatus,
     CryptographicParameters,
     NextAccountNonce,
-    PoolStatus,
     RewardStatus,
     TransactionStatus,
     Versioned,
@@ -121,8 +121,8 @@ export type GRPC = {
     getRewardStatus: (blockHash: string) => Promise<RewardStatus | undefined>;
     getPoolStatus: (
         blockHash: string,
-        bakerId?: BakerId
-    ) => Promise<PoolStatus | undefined>;
+        bakerId: BakerId
+    ) => Promise<BakerPoolStatus | undefined>;
 };
 
 export type FileMethods = {

--- a/app/utils/init/closingBakerPoolChecker.ts
+++ b/app/utils/init/closingBakerPoolChecker.ts
@@ -2,7 +2,6 @@ import { isDelegatorAccount } from '@concordium/node-sdk/lib/src/accountHelpers'
 import {
     BakerPoolPendingChangeType,
     DelegationTargetType,
-    PoolStatusType,
 } from '@concordium/node-sdk/lib/src/types';
 import { Account, AccountStatus, Dispatch } from '../types';
 import { findAccounts } from '~/database/AccountDao';
@@ -28,16 +27,11 @@ async function findAccountsDelegatingToClosingBakerPools() {
         ) {
             const { bakerId } = accountInfo.accountDelegation.delegationTarget;
             const poolStatus = await getPoolStatusLatest(bakerId);
-
-            // TODO: This is always true (we checked that the account is delegating to a baker),
-            // but our typing is not good enough here, so we need yet another guard.
-            if (poolStatus.poolType === PoolStatusType.BakerPool) {
-                if (
-                    poolStatus.bakerStakePendingChange.pendingChangeType ===
-                    BakerPoolPendingChangeType.RemovePool
-                ) {
-                    accountsDelegatingToClosingPool.push(account);
-                }
+            if (
+                poolStatus.bakerStakePendingChange.pendingChangeType ===
+                BakerPoolPendingChangeType.RemovePool
+            ) {
+                accountsDelegatingToClosingPool.push(account);
             }
         }
     }


### PR DESCRIPTION
## Purpose
Improve typing of `getPoolStatus` as we know it is a baker pool status when a baker id is provided.

## Changes
- Updated types from the generic `PoolStatus` to `BakerPoolStatus` as we never use the passive delegation status.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.