### PR TITLE
Use V0 guards where applicable

### DIFF
--- a/app/pages/Accounts/AccountDetailsPage/Baking/AddBaker.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/Baking/AddBaker.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/display-name */
 import React, { ComponentType, useCallback } from 'react';
 import type { BlockSummaryV1 } from '@concordium/node-sdk';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { Redirect } from 'react-router';
 import withExchangeRate from '~/components/Transfers/withExchangeRate';
 import withNonce, { AccountAndNonce } from '~/components/Transfers/withNonce';
@@ -67,7 +67,7 @@ const withDeps = (component: ComponentType<Deps>) =>
 const ensureDelegationProtocol = (c: ComponentType<Props>) =>
     ensureProps<Props, Deps>(
         c,
-        (p): p is Props => isBlockSummaryV1(p.blockSummary),
+        (p): p is Props => !isBlockSummaryV0(p.blockSummary),
         <Redirect to={routes.ACCOUNTS} />
     );
 

--- a/app/pages/Accounts/AccountDetailsPage/Baking/UpdateBakerPool.tsx
+++ b/app/pages/Accounts/AccountDetailsPage/Baking/UpdateBakerPool.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import type { BlockSummaryV1 } from '@concordium/node-sdk';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import React, { ComponentType, useCallback, useState } from 'react';
 import { Redirect } from 'react-router';
 import withExchangeRate from '~/components/Transfers/withExchangeRate';
@@ -63,7 +63,7 @@ const withDeps = (component: ComponentType<Deps>) =>
 const ensureDelegationProtocol = (c: ComponentType<Props>) =>
     ensureProps<Props, Deps>(
         c,
-        (p): p is Props => isBlockSummaryV1(p.blockSummary),
+        (p): p is Props => !isBlockSummaryV0(p.blockSummary),
         <Redirect to={routes.ACCOUNTS} />
     );
 

--- a/app/pages/multisig/AccountTransactions/AddBaker.tsx
+++ b/app/pages/multisig/AccountTransactions/AddBaker.tsx
@@ -3,7 +3,7 @@ import React, { ComponentType, useCallback } from 'react';
 import { Redirect } from 'react-router';
 import { useSelector } from 'react-redux';
 import type { BlockSummaryV1, ChainParametersV1 } from '@concordium/node-sdk';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import {
     isBakerAccount,
     isDelegatorAccount,
@@ -160,7 +160,7 @@ const withDeps = (component: ComponentType<Deps>) =>
 const ensureDelegationProtocol = (c: ComponentType<Props>) =>
     ensureProps<Props, Deps>(
         c,
-        (p): p is Props => isBlockSummaryV1(p.blockSummary),
+        (p): p is Props => !isBlockSummaryV0(p.blockSummary),
         toRoot
     );
 

--- a/app/pages/multisig/AccountTransactions/UpdateBakerPool.tsx
+++ b/app/pages/multisig/AccountTransactions/UpdateBakerPool.tsx
@@ -3,7 +3,7 @@ import React, { ComponentType, useCallback, useState } from 'react';
 import { Redirect } from 'react-router';
 import { useSelector } from 'react-redux';
 import type { BlockSummaryV1 } from '@concordium/node-sdk';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { isBakerAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
 import CommissionsPage from '~/components/Transfers/configureBaker/CommissionsPage';
 import DelegationStatusPage from '~/components/Transfers/configureBaker/DelegationStatusPage';
@@ -143,7 +143,7 @@ const withDeps = (component: ComponentType<Deps>) =>
 const ensureDelegationProtocol = (c: ComponentType<Props>) =>
     ensureProps<Props, Deps>(
         c,
-        (p): p is Props => isBlockSummaryV1(p.blockSummary),
+        (p): p is Props => !isBlockSummaryV0(p.blockSummary),
         toRoot
     );
 

--- a/app/pages/multisig/updates/CooldownParameters/CooldownParametersView.tsx
+++ b/app/pages/multisig/updates/CooldownParameters/CooldownParametersView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { CooldownParameters } from '~/utils/types';
 import Loading from '~/cross-app-components/Loading';
 import withChainData, { ChainData } from '~/utils/withChainData';
@@ -21,7 +21,7 @@ export default withChainData(function CooldownParametersView({
     if (!consensusStatus || !blockSummary) {
         return <Loading inline />;
     }
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/pages/multisig/updates/CooldownParameters/UpdateCooldownParameters.tsx
+++ b/app/pages/multisig/updates/CooldownParameters/UpdateCooldownParameters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { EqualRecord } from '~/utils/types';
 import { UpdateProps } from '~/utils/transactionTypes';
 import Form from '~/components/Form/';
@@ -27,7 +27,7 @@ export default function UpdateCooldownParameters({
     defaults,
     blockSummary,
 }: UpdateProps): JSX.Element | null {
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/pages/multisig/updates/MintDistribution/MintDistributionView.tsx
+++ b/app/pages/multisig/updates/MintDistribution/MintDistributionView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { MintDistribution } from '~/utils/types';
 import Loading from '~/cross-app-components/Loading';
 import withChainData, { ChainData } from '~/utils/withChainData';
@@ -31,7 +31,7 @@ export default withChainData(function MintDistributionView({
     if (!consensusStatus || !blockSummary) {
         return <Loading />;
     }
-    if (isBlockSummaryV1(blockSummary) && mintDistribution.version === 0) {
+    if (!isBlockSummaryV0(blockSummary) && mintDistribution.version === 0) {
         throw new Error(
             'Viewing mint distribution update version 0, which is outdated.'
         );
@@ -54,7 +54,7 @@ export default withChainData(function MintDistributionView({
         <>
             <div>
                 <Label className="mB5">Current mint distribution:</Label>
-                {isBlockSummaryV1(blockSummary) || (
+                {!isBlockSummaryV0(blockSummary) || (
                     <MintRateInput
                         value={blockSummary.updates.chainParameters.rewardParameters.mintDistribution.mintPerSlot.toString()}
                         paydaysPerYear={slotsPerYear}

--- a/app/pages/multisig/updates/MintDistribution/UpdateMintDistribution.tsx
+++ b/app/pages/multisig/updates/MintDistribution/UpdateMintDistribution.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Validate } from 'react-hook-form';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { EqualRecord } from '~/utils/types';
 import { UpdateProps } from '~/utils/transactionTypes';
 
@@ -52,7 +52,7 @@ export default function UpdateMintDistribution({
     let mintPerSlot: number | undefined;
     const rewardDistribution =
         blockSummary.updates.chainParameters.rewardParameters.mintDistribution;
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         mintPerSlot =
             blockSummary.updates.chainParameters.rewardParameters
                 .mintDistribution.mintPerSlot;

--- a/app/pages/multisig/updates/PoolParameters/PoolParametersView.tsx
+++ b/app/pages/multisig/updates/PoolParameters/PoolParametersView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { PoolParameters } from '~/utils/types';
 import Loading from '~/cross-app-components/Loading';
 import withChainData, { ChainData } from '~/utils/withChainData';
@@ -21,7 +21,7 @@ export default withChainData(function PoolParametersView({
     if (!consensusStatus || !blockSummary) {
         return <Loading inline />;
     }
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/pages/multisig/updates/PoolParameters/UpdatePoolParameters.tsx
+++ b/app/pages/multisig/updates/PoolParameters/UpdatePoolParameters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import {
     RegisterOptions,
     useFormContext,
@@ -86,7 +86,7 @@ export default function UpdatePoolParameters({
     defaults,
     blockSummary,
 }: UpdateProps): JSX.Element | null {
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/pages/multisig/updates/TimeParameters/TimeParametersView.tsx
+++ b/app/pages/multisig/updates/TimeParameters/TimeParametersView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { TimeParameters } from '~/utils/types';
 import Loading from '~/cross-app-components/Loading';
 import withChainData, { ChainData } from '~/utils/withChainData';
@@ -23,7 +23,7 @@ export default withChainData(function TimeParametersView({
     if (!consensusStatus || !blockSummary) {
         return <Loading inline />;
     }
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/pages/multisig/updates/TimeParameters/UpdateTimeParameters.tsx
+++ b/app/pages/multisig/updates/TimeParameters/UpdateTimeParameters.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Validate, useFormContext } from 'react-hook-form';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { EqualRecord } from '~/utils/types';
 import { UpdateProps } from '~/utils/transactionTypes';
 import Form from '~/components/Form/';
@@ -45,7 +45,7 @@ export default function UpdateTimeParameters({
     blockSummary,
     consensusStatus,
 }: UpdateProps): JSX.Element | null {
-    if (!isBlockSummaryV1(blockSummary)) {
+    if (isBlockSummaryV0(blockSummary)) {
         throw new Error('Connected node used outdated blockSummary format');
     }
 

--- a/app/utils/blockSummaryHelpers.ts
+++ b/app/utils/blockSummaryHelpers.ts
@@ -1,11 +1,10 @@
 /* eslint-disable import/prefer-default-export */
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { BlockSummary } from '~/node/NodeApiTypes';
 
 export function getMinimumStakeForBaking(bs: BlockSummary): bigint {
-    if (isBlockSummaryV1(bs)) {
-        return bs.updates.chainParameters.minimumEquityCapital;
+    if (isBlockSummaryV0(bs)) {
+        return bs.updates.chainParameters.minimumThresholdForBaking;
     }
-
-    return bs.updates.chainParameters.minimumThresholdForBaking;
+    return bs.updates.chainParameters.minimumEquityCapital;
 }

--- a/app/utils/dataHooks.ts
+++ b/app/utils/dataHooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
-    isBlockSummaryV1,
-    isChainParametersV1,
+    isBlockSummaryV0,
+    isChainParametersV0,
 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { isRewardStatusV1 } from '@concordium/node-sdk/lib/src/rewardStatusHelpers';
 import { isBakerAccount } from '@concordium/node-sdk/lib/src/accountHelpers';
@@ -169,7 +169,7 @@ export function useChainParameters() {
  */
 export function useCapitalBound() {
     const chainParameters = useChainParameters();
-    if (!chainParameters || !isChainParametersV1(chainParameters)) {
+    if (!chainParameters || isChainParametersV0(chainParameters)) {
         return undefined;
     }
     return chainParameters.capitalBound;
@@ -291,22 +291,24 @@ export function useCalcDelegatorCooldownUntil() {
 
     const { bs, cs, rs } = status;
 
-    if (isBlockSummaryV1(bs)) {
-        if (!isRewardStatusV1(rs)) {
-            // Should not happen, as this indicates rs and bs were queried for with different blocks.
-            throwLoggedError('Block summary and reward status do not match.');
-        }
-
-        return getV1Cooldown(
-            Number(bs.updates.chainParameters.delegatorCooldown),
-            bs,
-            cs,
-            rs.nextPaydayTime,
-            now
+    if (isBlockSummaryV0(bs)) {
+        throwLoggedError(
+            'Delegation cooldown not available for current protocol version.'
         );
     }
-    return throwLoggedError(
-        'Delegation cooldown not available for current protocol version.'
+
+    // TODO: Handle V2 rewardStatus if it is added
+    if (!isRewardStatusV1(rs)) {
+        // Should not happen, as this indicates rs and bs were queried for with different blocks.
+        throwLoggedError('Block summary and reward status do not match.');
+    }
+
+    return getV1Cooldown(
+        Number(bs.updates.chainParameters.delegatorCooldown),
+        bs,
+        cs,
+        rs.nextPaydayTime,
+        now
     );
 }
 
@@ -321,24 +323,25 @@ export function useCalcBakerStakeCooldownUntil() {
 
     const { bs, cs, rs } = status;
 
-    if (isBlockSummaryV1(bs)) {
-        if (!isRewardStatusV1(rs)) {
-            // Should not happen, as this indicates rs and bs were queried for with different blocks.
-            throwLoggedError('Block summary and reward status do not match.');
-        }
-
-        return getV1Cooldown(
-            Number(bs.updates.chainParameters.poolOwnerCooldown),
-            bs,
+    if (isBlockSummaryV0(bs)) {
+        return getV0Cooldown(
+            Number(bs.updates.chainParameters.bakerCooldownEpochs),
             cs,
-            rs.nextPaydayTime,
             now
         );
     }
 
-    return getV0Cooldown(
-        Number(bs.updates.chainParameters.bakerCooldownEpochs),
+    // TODO: Handle V2 rewardStatus if it is added
+    if (!isRewardStatusV1(rs)) {
+        // Should not happen, as this indicates rs and bs were queried for with different blocks.
+        throwLoggedError('Block summary and reward status do not match.');
+    }
+
+    return getV1Cooldown(
+        Number(bs.updates.chainParameters.poolOwnerCooldown),
+        bs,
         cs,
+        rs.nextPaydayTime,
         now
     );
 }
@@ -357,17 +360,18 @@ export function useStakeIncreaseUntil() {
 
     const { bs, cs, rs } = status;
 
-    if (isBlockSummaryV1(bs)) {
-        if (!isRewardStatusV1(rs)) {
-            // Should not happen, as this indicates rs and bs were queried for with different blocks.
-            throwLoggedError('Block summary and reward status do not match.');
-        }
-
-        return getV1Cooldown(0, bs, cs, rs.nextPaydayTime, now);
+    if (isBlockSummaryV0(bs)) {
+        // In V0, stake increase takes effect after 2 epochs
+        return getV0Cooldown(2, cs, now);
     }
 
-    // In V0, stake increase takes effect after 2 epochs
-    return getV0Cooldown(2, cs, now);
+    // TODO: Handle V2 rewardStatus if it is added
+    if (!isRewardStatusV1(rs)) {
+        // Should not happen, as this indicates rs and bs were queried for with different blocks.
+        throwLoggedError('Block summary and reward status do not match.');
+    }
+
+    return getV1Cooldown(0, bs, cs, rs.nextPaydayTime, now);
 }
 
 /**

--- a/app/utils/dataHooks.ts
+++ b/app/utils/dataHooks.ts
@@ -297,7 +297,6 @@ export function useCalcDelegatorCooldownUntil() {
         );
     }
 
-    // TODO: Handle V2 rewardStatus if it is added
     if (!isRewardStatusV1(rs)) {
         // Should not happen, as this indicates rs and bs were queried for with different blocks.
         throwLoggedError('Block summary and reward status do not match.');
@@ -331,7 +330,6 @@ export function useCalcBakerStakeCooldownUntil() {
         );
     }
 
-    // TODO: Handle V2 rewardStatus if it is added
     if (!isRewardStatusV1(rs)) {
         // Should not happen, as this indicates rs and bs were queried for with different blocks.
         throwLoggedError('Block summary and reward status do not match.');
@@ -365,7 +363,6 @@ export function useStakeIncreaseUntil() {
         return getV0Cooldown(2, cs, now);
     }
 
-    // TODO: Handle V2 rewardStatus if it is added
     if (!isRewardStatusV1(rs)) {
         // Should not happen, as this indicates rs and bs were queried for with different blocks.
         throwLoggedError('Block summary and reward status do not match.');

--- a/app/utils/timeHelpers.ts
+++ b/app/utils/timeHelpers.ts
@@ -310,7 +310,6 @@ function dateFromPendingChangeEffectiveTime(
         return undefined;
     }
 
-    // TODO: Handle V2 rewardStatus if it is added
     if (!isRewardStatusV1(rs) || isChainParametersV0(cp)) {
         throw new Error(
             'Not possible to calculate date due to mismatch between reward status, chain parameters, and pending change versions.'

--- a/app/utils/timeHelpers.ts
+++ b/app/utils/timeHelpers.ts
@@ -6,9 +6,9 @@ import {
     RewardStatus,
     StakePendingChange,
 } from '@concordium/node-sdk/lib/src/types';
-import { isStakePendingChangeV1 } from '@concordium/node-sdk/lib/src/accountHelpers';
+import { isStakePendingChangeV0 } from '@concordium/node-sdk/lib/src/accountHelpers';
 import { isRewardStatusV1 } from '@concordium/node-sdk/lib/src/rewardStatusHelpers';
-import { isChainParametersV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isChainParametersV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import { ensureNumberLength } from './basicHelpers';
 import { TimeStampUnit, YearMonth, YearMonthDate } from './types';
 
@@ -310,7 +310,8 @@ function dateFromPendingChangeEffectiveTime(
         return undefined;
     }
 
-    if (!isRewardStatusV1(rs) || !isChainParametersV1(cp)) {
+    // TODO: Handle V2 rewardStatus if it is added
+    if (!isRewardStatusV1(rs) || isChainParametersV0(cp)) {
         throw new Error(
             'Not possible to calculate date due to mismatch between reward status, chain parameters, and pending change versions.'
         );
@@ -363,7 +364,7 @@ export function dateFromStakePendingChange(
         return undefined;
     }
 
-    if (!isStakePendingChangeV1(spc)) {
+    if (isStakePendingChangeV0(spc)) {
         return epochDate(
             Number(spc.epoch),
             cs.epochDuration,

--- a/app/utils/transactionHandlers/BakerStakeThresholdHandler.tsx
+++ b/app/utils/transactionHandlers/BakerStakeThresholdHandler.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import BakerStakeThresholdView from '~/pages/multisig/updates/BakerStakeThreshold/BakerStakeThresholdView';
 import UpdateBakerStakeThreshold, {
     UpdateBakerStakeThresholdFields,
@@ -37,11 +37,11 @@ export default class BakerStakeThresholdHandler
         effectiveTime: bigint,
         expiryTime: bigint
     ): Promise<Omit<MultiSignatureTransaction, 'id'> | undefined> {
-        if (!blockSummary || isBlockSummaryV1(blockSummary)) {
+        if (!blockSummary) {
             return undefined;
         }
 
-        if (isBlockSummaryV1(blockSummary)) {
+        if (!isBlockSummaryV0(blockSummary)) {
             throw new Error('Update incompatible with chain protocol version');
         }
 

--- a/app/utils/transactionHandlers/CooldownParametersHandler.tsx
+++ b/app/utils/transactionHandlers/CooldownParametersHandler.tsx
@@ -96,7 +96,6 @@ export default class CooldownParametersHandler
     }
 
     getAuthorization(authorizations: Authorizations) {
-        // TODO: Handle V2 authorizations if they are added
         if (!isAuthorizationsV1(authorizations)) {
             throw new Error('Connected node used outdated blockSummary format');
         }

--- a/app/utils/transactionHandlers/CooldownParametersHandler.tsx
+++ b/app/utils/transactionHandlers/CooldownParametersHandler.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    isBlockSummaryV1,
+    isBlockSummaryV0,
     isAuthorizationsV1,
 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import ConcordiumLedgerClient from '~/features/ledger/ConcordiumLedgerClient';
@@ -43,8 +43,12 @@ export default class CooldownParametersHandler
         effectiveTime: bigint,
         expiryTime: bigint
     ): Promise<Omit<MultiSignatureTransaction, 'id'> | undefined> {
-        if (!blockSummary || !isBlockSummaryV1(blockSummary)) {
+        if (!blockSummary) {
             return undefined;
+        }
+
+        if (isBlockSummaryV0(blockSummary)) {
+            throw new Error('Update incompatible with chain protocol version');
         }
 
         const sequenceNumber =
@@ -92,6 +96,7 @@ export default class CooldownParametersHandler
     }
 
     getAuthorization(authorizations: Authorizations) {
+        // TODO: Handle V2 authorizations if they are added
         if (!isAuthorizationsV1(authorizations)) {
             throw new Error('Connected node used outdated blockSummary format');
         }

--- a/app/utils/transactionHandlers/PoolParametersHandlers.tsx
+++ b/app/utils/transactionHandlers/PoolParametersHandlers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBlockSummaryV1 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
+import { isBlockSummaryV0 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import ConcordiumLedgerClient from '~/features/ledger/ConcordiumLedgerClient';
 import { getGovernanceLevel2Path } from '~/features/ledger/Path';
 import PoolParametersView from '~/pages/multisig/updates/PoolParameters/PoolParametersView';
@@ -47,8 +47,12 @@ export default class PoolParametersHandler
         effectiveTime: bigint,
         expiryTime: bigint
     ): Promise<Omit<MultiSignatureTransaction, 'id'> | undefined> {
-        if (!blockSummary || !isBlockSummaryV1(blockSummary)) {
+        if (!blockSummary) {
             return undefined;
+        }
+
+        if (isBlockSummaryV0(blockSummary)) {
+            throw new Error('Update incompatible with chain protocol version');
         }
 
         const sequenceNumber =

--- a/app/utils/transactionHandlers/TimeParameterHandler.tsx
+++ b/app/utils/transactionHandlers/TimeParameterHandler.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    isBlockSummaryV1,
+    isBlockSummaryV0,
     isAuthorizationsV1,
 } from '@concordium/node-sdk/lib/src/blockSummaryHelpers';
 import ConcordiumLedgerClient from '~/features/ledger/ConcordiumLedgerClient';
@@ -42,12 +42,12 @@ export default class TimeParametersHandler
         expiryTime: bigint
     ): Promise<Omit<MultiSignatureTransaction, 'id'> | undefined> {
         const parsedMintRate = parseMintRate(mintPerPayday);
-        if (
-            !blockSummary ||
-            !parsedMintRate ||
-            !isBlockSummaryV1(blockSummary)
-        ) {
+        if (!blockSummary || !parsedMintRate) {
             return undefined;
+        }
+
+        if (isBlockSummaryV0(blockSummary)) {
+            throw new Error('Update incompatible with chain protocol version');
         }
 
         const sequenceNumber =
@@ -92,6 +92,7 @@ export default class TimeParametersHandler
     }
 
     getAuthorization(authorizations: Authorizations) {
+        // TODO: Handle V2 authorizations if they are added
         if (!isAuthorizationsV1(authorizations)) {
             throw new Error('Connected node used outdated blockSummary format');
         }

--- a/app/utils/transactionHandlers/TimeParameterHandler.tsx
+++ b/app/utils/transactionHandlers/TimeParameterHandler.tsx
@@ -92,7 +92,6 @@ export default class TimeParametersHandler
     }
 
     getAuthorization(authorizations: Authorizations) {
-        // TODO: Handle V2 authorizations if they are added
         if (!isAuthorizationsV1(authorizations)) {
             throw new Error('Connected node used outdated blockSummary format');
         }


### PR DESCRIPTION
## Purpose

Some places we used type guards that the version (of some object) was not 1, and assuming then it was 0. Here we now check that it is 0 directly instead. (where we could)


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
