### PR TITLE
Fix 'add delegation' multisig name

### DIFF
--- a/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
+++ b/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
@@ -238,7 +238,7 @@ const configureDelegationLinks = (
             className={styles.link}
             to={routes.MULTISIGTRANSACTIONS_ADD_DELEGATION}
         >
-            Delegate to a pool
+            Register as a delegator
         </ButtonNavLink>
         <ButtonNavLink
             className={styles.link}

--- a/app/utils/transactionFlows/addDelegation.ts
+++ b/app/utils/transactionFlows/addDelegation.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const addDelegationTitle = 'Delegate to a pool';
+export const addDelegationTitle = 'Register as a delegator';


### PR DESCRIPTION
## Purpose

Add delegation/_Register as a delegator_ was still called _delegate to a pool_ in the multisig flow.

## Changes

_Delegate to a pool_ -> _Register as a delegator_

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.