### PR TITLE
Fix windows build without signing

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const builder = require('electron-builder');
 
 const targetNet = process.env.TARGET_NET;
-const skipSigning = process.env.SIGNING === 'skip';
+const skipSigning = process.env.SIGNING.includes('skip');
 
 let name;
 let productName;


### PR DESCRIPTION
## Purpose

Fixes check that windows should build without signing.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
