### PR TITLE
Rename L pool header to passive delegation in PoolParameters

### DIFF
--- a/app/pages/multisig/updates/PoolParameters/PoolParametersShow.tsx
+++ b/app/pages/multisig/updates/PoolParameters/PoolParametersShow.tsx
@@ -30,7 +30,7 @@ export default function ShowPoolParameters({
         <section>
             <h3>{title}</h3>
             <div>
-                <h5>L Pool commissions</h5>
+                <h5>Passive delegation commissions</h5>
                 <RewardFractionField
                     label={fieldDisplays.passiveTransactionCommission}
                     value={passiveTransactionCommission}

--- a/app/pages/multisig/updates/PoolParameters/UpdatePoolParameters.tsx
+++ b/app/pages/multisig/updates/PoolParameters/UpdatePoolParameters.tsx
@@ -128,7 +128,7 @@ export default function UpdatePoolParameters({
             <section>
                 <h3>New pool parameters</h3>
                 <div>
-                    <h5>L Pool commissions</h5>
+                    <h5>Passive delegation commissions</h5>
                     <FractionFieldForm
                         label={fieldDisplays.passiveTransactionCommission}
                         name={fieldNames.passiveTransactionCommission}


### PR DESCRIPTION
## Purpose

Noticed that in the pool parameters, a header still said L pool commissions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

