### PR TITLE
Cleanup handlers and listeners on all windows closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.2
+
+### Fixed
+
+-   Fixed an issue on macOS where an error popup would show after closing the main application window and opening it again.
+-   Fixed an issue on macOS where identity creation was not possible after closing the main application window and opening it again.
+
 ## 1.4.1
 
 ### Added

--- a/app/main/autoUpdate/index.ts
+++ b/app/main/autoUpdate/index.ts
@@ -1,1 +1,1 @@
-export { default } from './init';
+export { initAutoUpdate, removeAutoUpdateHandlersAndListeners } from './init';

--- a/app/main/autoUpdate/init.ts
+++ b/app/main/autoUpdate/init.ts
@@ -45,7 +45,26 @@ const handleUpdateDownloaded = (mainWindow: BrowserWindow) => async (
     }
 };
 
-export default function initAutoUpdate(mainWindow: BrowserWindow) {
+/**
+ * Removes all ipcMain handlers and auto update listeners added by
+ * 'initAutoUpdate'.
+ */
+export function removeAutoUpdateHandlersAndListeners() {
+    autoUpdater.removeAllListeners('update-available');
+    autoUpdater.removeAllListeners('error');
+    autoUpdater.removeAllListeners('update-downloaded');
+    ipcMain.removeHandler(triggerAppUpdate);
+    ipcMain.removeHandler(quitAndInstallUpdate);
+}
+
+/**
+ * Initializes the auto update functionality by setting up handlers
+ * and auto update listeners.
+ *
+ * If adding a new handler to this method, then ensure that 'removeAutoUpdateHandlersAndListeners'
+ * above is updated to keep in sync with this method.
+ */
+export function initAutoUpdate(mainWindow: BrowserWindow) {
     const canAutoUpdate =
         process.platform === 'win32' ||
         process.platform === 'darwin' ||

--- a/app/main/ipcHandlers.ts
+++ b/app/main/ipcHandlers.ts
@@ -141,7 +141,29 @@ export function saveFileDialog(opts: SaveDialogOptions) {
     return dialog.showSaveDialog(opts);
 }
 
-export default function initializeIpcHandlers(
+/**
+ * Removes all ipcMain handlers registered by 'initializeIpcHandler'.
+ */
+export function removeAllIpcHandlers() {
+    ipcMain.removeHandler(ipcCommands.getUserDataPath);
+    ipcMain.removeHandler(ipcCommands.print);
+    ipcMain.removeHandler(ipcCommands.openUrl);
+    ipcMain.removeHandler(ipcCommands.httpsGet);
+    ipcMain.removeHandler(ipcCommands.createView);
+    ipcMain.removeHandler(ipcCommands.removeView);
+    ipcMain.removeHandler(ipcCommands.resizeView);
+    ipcMain.removeHandler(ipcCommands.saveFileDialog);
+    ipcMain.removeHandler(ipcCommands.openFileDialog);
+    ipcMain.removeHandler(ipcCommands.messageBox);
+}
+
+/**
+ * Initializes ipcMain handlers.
+ *
+ * If adding a new handler to this method, then ensure that 'removeAllIpcHandlers'
+ * above is updated to keep in sync with this method.
+ */
+export function initializeIpcHandlers(
     mainWindow: BrowserWindow,
     printWindow: BrowserWindow,
     browserView: BrowserView

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
     "name": "concordium-desktop-wallet",
     "productName": "concordium-desktop-wallet",
     "description": "concordium-desktop-wallet",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "main": "./main.prod.js",
     "author": {
         "name": "Concordium Software",


### PR DESCRIPTION
## Purpose
Fix a macOS specific issue where closing the main window (pressing `x` in the upper-left corner) causes both an error popup when the window is recreated, and also prevents the user from creating an identity until the application is completely restarted.

Note: This will result in a macOS specific update for testnet and mainnet.

## Changes
- Remove ipc handlers and auto update event listeners when all windows are closed on macOS. This is only relevant on macOS, as on Linux and Windows the entire application is destroyed when the last window is closed. This ensures that we stop trying to create duplicate handlers and also that we don't keep old handlers with references to destroyed objects.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.