### PR TITLE
Fix auto update: Stop polyfilling in preload and main scripts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
     "name": "concordium-desktop-wallet",
     "productName": "concordium-desktop-wallet",
     "description": "concordium-desktop-wallet",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "main": "./main.prod.js",
     "author": {
         "name": "Concordium Software",
@@ -22,4 +22,3 @@
         "sqlite3": "5.0.0"
     }
 }
-

--- a/configs/partials/webpack.config.base.js
+++ b/configs/partials/webpack.config.base.js
@@ -66,10 +66,6 @@ module.exports = {
                 extensions,
             }),
         ],
-        fallback: {
-            crypto: require.resolve('crypto-browserify'),
-            stream: require.resolve('stream-browserify'),
-        },
     },
 
     optimization: {
@@ -86,9 +82,6 @@ module.exports = {
             DEBUG_PROD: false,
             START_MINIMIZED: false,
             E2E_BUILD: false,
-        }),
-        new webpack.ProvidePlugin({
-            Buffer: ['buffer/', 'Buffer'],
         }),
         new webpack.NormalModuleReplacementPlugin(
             /\.\.\/migrations/,

--- a/configs/webpack.config.renderer.dev.dll.js
+++ b/configs/webpack.config.renderer.dev.dll.js
@@ -43,6 +43,13 @@ module.exports = merge(baseConfig, {
         libraryTarget: 'var',
     },
 
+    resolve: {
+        fallback: {
+            crypto: require.resolve('crypto-browserify'),
+            stream: require.resolve('stream-browserify'),
+        },
+    },
+
     plugins: [
         new webpack.DllPlugin({
             path: path.join(dist, '[name].json'),
@@ -61,7 +68,9 @@ module.exports = merge(baseConfig, {
         new webpack.EnvironmentPlugin({
             NODE_ENV: 'development',
         }),
-
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer/', 'Buffer'],
+        }),
         new webpack.LoaderOptionsPlugin({
             debug: true,
             options: {

--- a/configs/webpack.config.renderer.dev.js
+++ b/configs/webpack.config.renderer.dev.js
@@ -72,6 +72,10 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(false), {
         alias: {
             'react-dom': '@hot-loader/react-dom',
         },
+        fallback: {
+            crypto: require.resolve('crypto-browserify'),
+            stream: require.resolve('stream-browserify'),
+        },
     },
     optimization: {
         emitOnErrors: false,
@@ -94,6 +98,7 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(false), {
         }),
         new webpack.ProvidePlugin({
             process: 'process/browser',
+            Buffer: ['buffer/', 'Buffer'],
         }),
     ],
 

--- a/configs/webpack.config.renderer.prod.js
+++ b/configs/webpack.config.renderer.prod.js
@@ -59,6 +59,13 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(true), {
         asyncWebAssembly: true,
     },
 
+    resolve: {
+        fallback: {
+            crypto: require.resolve('crypto-browserify'),
+            stream: require.resolve('stream-browserify'),
+        },
+    },
+
     plugins: [
         new webpack.EnvironmentPlugin({
             NODE_ENV: 'production',
@@ -72,6 +79,7 @@ module.exports = merge(baseConfig, assetsConfig, stylesConfig(true), {
         }),
         new webpack.ProvidePlugin({
             process: 'process/browser',
+            Buffer: ['buffer/', 'Buffer'],
         }),
     ],
 });


### PR DESCRIPTION
## Purpose
To make the automatic updates functionality work for macOS again. Also fixes the update caching issue on other platforms, where the update would be re-downloaded even if already cached.

## Changes
- Stopped polyfilling in preload and main scripts.

## Testing
To verify that automatic updates now work one has to either fork the repository and set it up there, or edit the build to have a version prior to 1.4.1 so that it tries to update to that.

- Let the application download the update and close the application during the verification step. Then when opening the application again the output should say: "Update has already been downloaded to [...]" if the fix worked.
- When letting the automatic update complete it should actually install and launch the updated application. Especially important to check on macOS as this part also worked on Linux even with the bug present.
- General usage of the desktop wallet should be confirmed to still work as the polyfills are a global setting that could have broken something elsewhere.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.