### PR TITLE
Delegation link

### DIFF
--- a/app/components/ManualUpdateNotification.tsx
+++ b/app/components/ManualUpdateNotification.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const downloadUrl =
-    'https://developer.concordium.software/en/testnet/net/installation/downloads.html#concordium-desktop-wallet';
+    'https://developer.concordium.software/en/mainnet/net/installation/downloads.html#concordium-desktop-wallet';
 
 export default function ManualUpdateNotification({ version, onClose }: Props) {
     return (

--- a/app/components/ManualUpdateNotification.tsx
+++ b/app/components/ManualUpdateNotification.tsx
@@ -3,14 +3,12 @@ import CogIcon from '@resources/svg/settings.svg';
 import Notification from './Notification';
 import { NotificationLevel } from '~/features/NotificationSlice';
 import Button from '~/cross-app-components/Button';
+import urls from '~/constants/urls.json';
 
 interface Props {
     version: string;
     onClose(): void;
 }
-
-const downloadUrl =
-    'https://developer.concordium.software/en/mainnet/net/installation/downloads.html#concordium-desktop-wallet';
 
 export default function ManualUpdateNotification({ version, onClose }: Props) {
     return (
@@ -24,7 +22,12 @@ export default function ManualUpdateNotification({ version, onClose }: Props) {
                 <span className="mL5">Version {version} is available.</span>
             </div>
             <div className="inlineFlexColumn mT20">
-                <Button size="tiny" onClick={() => window.openUrl(downloadUrl)}>
+                <Button
+                    size="tiny"
+                    onClick={() =>
+                        window.openUrl(urls.desktopWalletDownloadPageMainnet)
+                    }
+                >
                     Open website
                 </Button>
                 <Button className="mT10" size="tiny" onClick={onClose}>

--- a/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
@@ -128,24 +128,32 @@ export default function DelegationTargetPage({
                             }}
                         />
                         <p className="mB30">
-                            If you don&apos;t already know what baker pool you
-                            want to delegate an amount to, you can read more
-                            about finding one here:
+                            If you don&apos;t already know which baker pool you
+                            want to delegate an amount to, you can look for one
+                            here:
+                        </p>
+                        <p className="mV0">
+                            <ExternalLink href={urls.ccdScanStakingPage}>
+                                CCDScan.io/staking
+                            </ExternalLink>
                         </p>
                     </>
                 ) : (
-                    <p className="mB20">
-                        Passive delegation is an alternative to delegation to a
-                        specific baker pool that has lower rewards. With passive
-                        delegation you do not have to worry about the uptime or
-                        quality of a baker node. For more info you can visit:
-                    </p>
+                    <>
+                        <p className="mB20">
+                            Passive delegation is an alternative to delegation
+                            to a specific baker pool that has lower rewards.
+                            With passive delegation you do not have to worry
+                            about the uptime or quality of a baker node. For
+                            more info you can visit:
+                        </p>
+                        <p className="mV0">
+                            <ExternalLink href={urls.delegationDocumention}>
+                                developer.concordium.software
+                            </ExternalLink>
+                        </p>
+                    </>
                 )}
-                <p className="mV0">
-                    <ExternalLink href={urls.delegationDocumention}>
-                        developer.concordium.software
-                    </ExternalLink>
-                </p>
             </div>
             <Form.Submit className={styles.continue}>Continue</Form.Submit>
         </Form>

--- a/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
+++ b/app/components/Transfers/configureDelegation/DelegationTargetPage.tsx
@@ -15,6 +15,7 @@ import { AccountInfo, EqualRecord, NotOptional } from '~/utils/types';
 import urls from '~/constants/urls.json';
 
 import styles from './DelegationPage.module.scss';
+import { getTargetNet, Net } from '~/utils/ConfigHelper';
 
 interface FormState {
     toSpecificPool: boolean;
@@ -133,9 +134,19 @@ export default function DelegationTargetPage({
                             here:
                         </p>
                         <p className="mV0">
-                            <ExternalLink href={urls.ccdScanStakingPage}>
-                                CCDScan.io/staking
-                            </ExternalLink>
+                            {getTargetNet() === Net.Mainnet ? (
+                                <ExternalLink
+                                    href={urls.ccdScanStakingPageMainnet}
+                                >
+                                    CCDScan.io/staking
+                                </ExternalLink>
+                            ) : (
+                                <ExternalLink
+                                    href={urls.ccdScanStakingPageTestnet}
+                                >
+                                    testnet.CCDScan.io/staking
+                                </ExternalLink>
+                            )}
                         </p>
                     </>
                 ) : (

--- a/app/constants/urls.json
+++ b/app/constants/urls.json
@@ -6,5 +6,7 @@
     "licenseNotices": "https://developer.concordium.software/en/mainnet/net/resources/dw-licenses.html",
     "supportForum": "https://support.concordium.software",
     "delegationDocumention": "https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html",
-    "ccdScanStakingPage": "https://ccdscan.io/staking"
+    "ccdScanStakingPageMainnet": "https://ccdscan.io/staking",
+    "ccdScanStakingPageTestnet": "https://testnet.ccdscan.io/staking",
+    "desktopWalletDownloadPageMainnet": "https://developer.concordium.software/en/mainnet/net/installation/downloads.html#concordium-desktop-wallet"
 }

--- a/app/constants/urls.json
+++ b/app/constants/urls.json
@@ -5,5 +5,6 @@
     "walletProxyProtonet": "https://wallet-proxy.protonet.concordium.com/",
     "licenseNotices": "https://developer.concordium.software/en/mainnet/net/resources/dw-licenses.html",
     "supportForum": "https://support.concordium.software",
-    "delegationDocumention": "https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html"
+    "delegationDocumention": "https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html",
+    "ccdScanStakingPage": "https://ccdscan.io/staking"
 }


### PR DESCRIPTION
## Purpose
When delegating to a baker we want to provide help so that the user can find a nice pool to join.

## Changes
- Now links to ccdscan/staking where baker pools can be found.
- Fixed the download page link in manual update notifications (rpm / deb) to point to mainnet instead of testnet.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.