### PR TITLE
Allow changing restake when below threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.2
+
+### Fixed
+
+-   Allow validators to change restaking preference while below minimum threshold
+
 ## 1.7.1
 
 ### Changed

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
     "name": "concordium-desktop-wallet",
     "productName": "concordium-desktop-wallet",
     "description": "concordium-desktop-wallet",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "main": "./main.prod.js",
     "author": {
         "name": "Concordium Software",

--- a/app/utils/transactionHelpers.ts
+++ b/app/utils/transactionHelpers.ts
@@ -4,6 +4,7 @@ import {
     ReleaseSchedule,
     TransactionSummaryType,
     TransactionKindString,
+    isBakerAccount,
 } from '@concordium/web-sdk';
 import { Validate } from 'react-hook-form';
 import {
@@ -682,7 +683,16 @@ export function validateBakerStake(
         return 'Value is not a valid CCD amount';
     }
     const amount = ccdToMicroCcd(amountToValidate);
-    if (bakerStakeThreshold && bakerStakeThreshold > amount) {
+    const currentStake: bigint | undefined =
+        accountInfo && isBakerAccount(accountInfo)
+            ? accountInfo.accountBaker.stakedAmount
+            : undefined;
+
+    if (
+        bakerStakeThreshold &&
+        bakerStakeThreshold > amount &&
+        (!currentStake || amount !== currentStake)
+    ) {
         return `Stake is below the threshold (${displayAsCcd(
             bakerStakeThreshold
         )}) for validation`;

--- a/test/utils/transactionHelpers.test.ts
+++ b/test/utils/transactionHelpers.test.ts
@@ -1,5 +1,9 @@
 import '../mockWindow';
-import { createRegularIntervalSchedule } from '../../app/utils/transactionHelpers';
+import { AccountInfo } from '@concordium/web-sdk';
+import {
+    createRegularIntervalSchedule,
+    validateBakerStake,
+} from '../../app/utils/transactionHelpers';
 
 test('createRegularIntervalSchedule release amounts should sum to input amount', () => {
     const totalAmount = 100n;
@@ -43,4 +47,46 @@ test('createRegularIntervalSchedule should increase timestamps by interval', () 
             true
         )
     ).toEqual(true);
+});
+
+test('validateBakerStake allows amount below threshold (if equal to currentStake)', () => {
+    const stakedAmount = 1000000n; // microCCD (1 CCD)
+    const accountAmount = 1000000000n; // microCCD (1000 CCD)
+    const accountInfo = {
+        accountAmount,
+        accountBaker: { stakedAmount },
+    } as AccountInfo;
+    const threshold = 100000000n; // microCCD (100 CCD)
+    const amount = '1'; // CCD
+    expect(
+        validateBakerStake(threshold, amount, accountInfo, 1n)
+    ).toBeUndefined();
+});
+
+test('validateBakerStake does not allow amount below threshold (if not equal to currentStake)', () => {
+    const stakedAmount = 1000000n; // microCCD (1 CCD)
+    const accountAmount = 1000000000n; // microCCD (1000 CCD)
+    const accountInfo = {
+        accountAmount,
+        accountBaker: { stakedAmount },
+    } as AccountInfo;
+    const threshold = 100000000n; // microCCD (100 CCD)
+    const amount = '5'; // CCD
+    expect(validateBakerStake(threshold, amount, accountInfo, 1n)).toContain(
+        'below the threshold'
+    );
+});
+
+test('validateBakerStake allows amount equal threshold', () => {
+    const stakedAmount = 1000000n; // microCCD (1 CCD)
+    const accountAmount = 1000000000n; // microCCD (1000 CCD)
+    const accountInfo = {
+        accountAmount,
+        accountBaker: { stakedAmount },
+    } as AccountInfo;
+    const threshold = 100000000n; // microCCD (100 CCD)
+    const amount = '100'; // CCD
+    expect(
+        validateBakerStake(threshold, amount, accountInfo, 1n)
+    ).toBeUndefined();
 });


### PR DESCRIPTION
## Purpose

Allow changing restake when below threshold

## Changes

- Don't fail baker check if below threshold and chosen amount is equal to stake.
- Made some tests.
- Bumped version.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
