### PR TITLE
Add set +e to not fail on error code 254 from awscli

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
         env:
           TAG: ${{ github.ref_name}}
         run: |
+          set +e
           # Extract version number
           VERSION=$(jq '.version' -r app/package.json)
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
         env:
           TAG: ${{ github.ref_name}}
         run: |
-          set +e
+          set +e #Github actions as default runs: 'set -e' before every shell run, so setting this to not fail when a return code is not 0.
           # Extract version number
           VERSION=$(jq '.version' -r app/package.json)
 


### PR DESCRIPTION
## Purpose

set +e to not fail completely when awscli gives return code 254

## Changes

Add set +e to shell command.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
