### PR TITLE
fix(node versions): Use node 18 for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ env:
   S3_BUCKET: "s3://desktopwallet.concordium.com"
   ECR_REPO: "192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/desktop-wallet-ci"
   WASM-PACK_VERSION: "v0.9.1"
-  NODE_VERSION: "14.16.0"
+  NODE_VERSION: 18
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
 
 permissions:

--- a/scripts/desktop-wallet-ci.Dockerfile
+++ b/scripts/desktop-wallet-ci.Dockerfile
@@ -13,14 +13,15 @@ RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     rpm \
     awscli
-    
+
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 # Default value is set in Github Actions
 ARG NODE_VERSION
 RUN . $NVM_DIR/nvm.sh \
     && nvm install ${NODE_VERSION} \
-    && npm install --global yarn \
+    # no need to install yarn globally if we're using corepack
+    #&& npm install --global yarn \
     && nvm use ${NODE_VERSION}
 
 ENV PATH=$NVM_DIR/versions/node/v${NODE_VERSION}/bin:${PATH}


### PR DESCRIPTION
## Purpose

Fix the 'yarn is installed globally' error in the release pipeline

## Changes

Changed from node 14.16.0 to node 18 in release github pipeline (to match the Build Lint and Test workflow)
Stop installing yarn globally in the desktop-wallet-ci Dockerfile since corepack should now handle that


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
