### PR TITLE
Remove LinuxDeploy AppImage step from GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,11 +133,6 @@ jobs:
           # Install OpenSSL development files (static libs)
           sudo apt-get install -y libssl-dev
 
-          # Download linuxdeploy for AppImage creation
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-          chmod +x linuxdeploy-x86_64.AppImage
-          ./linuxdeploy-x86_64.AppImage --version
-
       - name: Install Node packages
         env:
           # Prevent corepack from prompting for permission to download.
@@ -215,14 +210,6 @@ jobs:
           OPENSSL_DIR: "/usr/lib/ssl" 
           PKG_CONFIG_ALLOW_CROSS: "1"
         run: yarn package
-
-      # --- New step to create AppImage for Linux only ---
-      - name: Create AppImage with linuxdeploy
-        if: matrix.platform.id == 'linux'
-        run: |
-          ./linuxdeploy-x86_64.AppImage --appdir=release/concordium-desktop-wallet.AppDir \
-            --output appimage \
-            --executable=release/concordium-desktop-wallet.AppDir/usr/bin/concordium-desktop-wallet
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Purpose

Fixed issues with LinuxDeploy

## Changes

This PR removes the manual Linuxdeploy AppImage creation step from the release.yaml workflow.
The AppImage is already generated automatically during the build process.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
