### PR TITLE
Open SSL install fix in release file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,12 +125,15 @@ jobs:
           # Install libssl1.1 manually on Ubuntu 22.04 and 24.04 if missing
           if ! dpkg -s libssl1.1 >/dev/null 2>&1; then
             echo "::group::Installing OpenSSL 1.1 manually"
-            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.1/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
+            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
+            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
+            sudo dpkg -i libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
             echo "::endgroup::"
           fi
 
           # Install OpenSSL development files (static libs)
+          sudo apt-get update
           sudo apt-get install -y libssl-dev
 
       - name: Install Node packages
@@ -243,7 +246,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install native packages
-        run: sudo apt-get install -y libusb-1.0 libudev-dev rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0 libudev-dev rpm
 
       - name: Install Node packages
         env:


### PR DESCRIPTION
## Purpose

Fixed GitHub Actions workflow that installs OpenSSL 1.1 (`libssl1.1` and `libssl-dev`) on modern Ubuntu runners 

## Changes

- Downloads OpenSSL 1.1 packages (`libssl1.1` and `libssl-dev`) from the official Ubuntu 20.04 security archive.
- Installs them manually using `dpkg -i`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
