### PR TITLE
Add Separate Menu for Governance Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a separate menu for governance transactions in multi sig panel
+
 ## 1.8.2
 
 ### Fixed

--- a/app/constants/routes.json
+++ b/app/constants/routes.json
@@ -45,6 +45,7 @@
     "RECOVERY_MAIN": "/settings/recovery/main",
     "RECOVERY_COMPLETED": "/settings/recovery/completed",
     "MULTISIGTRANSACTIONS": "/multi-signature-transaction",
+    "MULTISIGTRANSACTIONS_GOV": "/multi-signature-transaction/governance",
     "MULTISIGTRANSACTIONS_PROPOSAL": "/multi-signature-transaction/create/:updateType",
     "MULTISIGTRANSACTIONS_PROPOSAL_KEY_SET_SIZE": "/multi-signature-transaction/create/:updateType/keysetsize",
     "MULTISIGTRANSACTIONS_PROPOSAL_SET_EFFECTIVE_EXPIRY": "/multi-signature-transaction/create/:updateType/seteffectiveexpiry",

--- a/app/pages/multisig/MultiSignatureCreateProposal/MultiSignatureCreateProposal.tsx
+++ b/app/pages/multisig/MultiSignatureCreateProposal/MultiSignatureCreateProposal.tsx
@@ -157,7 +157,10 @@ function MultiSignatureCreateProposal({
 
 function LoadingComponent() {
     return (
-        <MultiSignatureLayout pageTitle="Create multisignature proposal" closeRoute={CLOSE_ROUTE}>
+        <MultiSignatureLayout
+            pageTitle="Create multisignature proposal"
+            closeRoute={CLOSE_ROUTE}
+        >
             <Loading text="Fetching information from the node" />
         </MultiSignatureLayout>
     );

--- a/app/pages/multisig/MultiSignatureCreateProposal/MultiSignatureCreateProposal.tsx
+++ b/app/pages/multisig/MultiSignatureCreateProposal/MultiSignatureCreateProposal.tsx
@@ -27,6 +27,8 @@ import { createProposalRoute } from '~/utils/routerHelper';
 import Loading from '~/cross-app-components/Loading';
 import { ensureUpdateQueue, WithUpdateQueues } from '~/utils/withUpdateQueue';
 
+const CLOSE_ROUTE = routes.MULTISIGTRANSACTIONS_GOV;
+
 export interface MultiSignatureCreateProposalForm {
     effectiveTime: Date;
     expiryTime: Date;
@@ -111,7 +113,7 @@ function MultiSignatureCreateProposal({
             <Modal
                 open={restrictionModalOpen}
                 onOpen={() => {}}
-                onClose={() => dispatch(push(routes.MULTISIGTRANSACTIONS))}
+                onClose={() => dispatch(push(CLOSE_ROUTE))}
             >
                 An unsubmitted update of this type already exists, and must be
                 submitted or cancelled, before a new update of the same kind can
@@ -133,6 +135,7 @@ function MultiSignatureCreateProposal({
                         <MultiSignatureLayout
                             pageTitle={handler.title}
                             delegateScroll={isKeyUpdate}
+                            closeRoute={CLOSE_ROUTE}
                         >
                             <BuildComponent
                                 type={type}
@@ -154,7 +157,7 @@ function MultiSignatureCreateProposal({
 
 function LoadingComponent() {
     return (
-        <MultiSignatureLayout pageTitle="Create multisignature proposal">
+        <MultiSignatureLayout pageTitle="Create multisignature proposal" closeRoute={CLOSE_ROUTE}>
             <Loading text="Fetching information from the node" />
         </MultiSignatureLayout>
     );

--- a/app/pages/multisig/MultiSignaturePage/MultiSignaturePage.tsx
+++ b/app/pages/multisig/MultiSignaturePage/MultiSignaturePage.tsx
@@ -12,7 +12,10 @@ import ImportProposal from '../menu/ImportProposal';
 import ProposalList from '../menu/ProposalList';
 
 import styles from './MultiSignaturePage.module.scss';
-import { MultiSignatureCreateAccountProposalView, MultiSignatureCreateGovernanceProposalView } from '../menu/MultiSignatureCreateProposalList';
+import {
+    MultiSignatureCreateAccountProposalView,
+    MultiSignatureCreateGovernanceProposalView,
+} from '../menu/MultiSignatureCreateProposalList';
 
 const { Header, Master, Detail } = MasterDetailPageLayout;
 
@@ -35,12 +38,12 @@ export default function MultiSignaturePage() {
                     Make new proposal
                 </ButtonNavLink>
                 {foundationTransactionsEnabled && (
-                <ButtonNavLink
-                    to={routes.MULTISIGTRANSACTIONS_GOV}
-                    className={styles.link}
-                >
-                    Make new governance proposal
-                </ButtonNavLink>
+                    <ButtonNavLink
+                        to={routes.MULTISIGTRANSACTIONS_GOV}
+                        className={styles.link}
+                    >
+                        Make new governance proposal
+                    </ButtonNavLink>
                 )}
                 <ButtonNavLink
                     to={routes.MULTISIGTRANSACTIONS_PROPOSAL_EXISTING}

--- a/app/pages/multisig/MultiSignaturePage/MultiSignaturePage.tsx
+++ b/app/pages/multisig/MultiSignaturePage/MultiSignaturePage.tsx
@@ -8,11 +8,11 @@ import routes from '~/constants/routes.json';
 
 import BrowseTransactionFile from '../menu/BrowseTransactionFile';
 import ExportKeyList from '../menu/ExportKeyList';
-import MultiSignatureCreateProposalList from '../menu/MultiSignatureCreateProposalList';
 import ImportProposal from '../menu/ImportProposal';
 import ProposalList from '../menu/ProposalList';
 
 import styles from './MultiSignaturePage.module.scss';
+import { MultiSignatureCreateAccountProposalView, MultiSignatureCreateGovernanceProposalView } from '../menu/MultiSignatureCreateProposalList';
 
 const { Header, Master, Detail } = MasterDetailPageLayout;
 
@@ -34,6 +34,14 @@ export default function MultiSignaturePage() {
                 >
                     Make new proposal
                 </ButtonNavLink>
+                {foundationTransactionsEnabled && (
+                <ButtonNavLink
+                    to={routes.MULTISIGTRANSACTIONS_GOV}
+                    className={styles.link}
+                >
+                    Make new governance proposal
+                </ButtonNavLink>
+                )}
                 <ButtonNavLink
                     to={routes.MULTISIGTRANSACTIONS_PROPOSAL_EXISTING}
                     className={styles.link}
@@ -65,8 +73,12 @@ export default function MultiSignaturePage() {
                 <Switch>
                     <Route
                         path={routes.MULTISIGTRANSACTIONS}
-                        component={MultiSignatureCreateProposalList}
+                        component={MultiSignatureCreateAccountProposalView}
                         exact
+                    />
+                    <Route
+                        path={routes.MULTISIGTRANSACTIONS_GOV}
+                        component={MultiSignatureCreateGovernanceProposalView}
                     />
                     <Route
                         path={routes.MULTISIGTRANSACTIONS_PROPOSAL_EXISTING}

--- a/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
+++ b/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
@@ -330,8 +330,8 @@ export function MultiSignatureCreateAccountProposalView() {
 
 /**
  * Component that displays a menu containing the available governance
- * transaction types. 
-*/
+ * transaction types.
+ */
 export function MultiSignatureCreateGovernanceProposalView() {
     const proposals = useSelector(proposalsSelector);
     const pv = useProtocolVersion(true);
@@ -339,11 +339,11 @@ export function MultiSignatureCreateGovernanceProposalView() {
         foundationTransactionsEnabledSelector
     );
     const dispatch = useDispatch();
-    
+
     useEffect(() => {
         return expireProposals(proposals, dispatch);
     }, [dispatch, proposals]);
-    
+
     return (
         <>
             {foundationTransactionsEnabled &&

--- a/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
+++ b/app/pages/multisig/menu/MultiSignatureCreateProposalList.tsx
@@ -301,6 +301,57 @@ const toLink = (pv: bigint | undefined) => ([
             {label}
         </ButtonNavLink>
     );
+
+/**
+ * Component that displays a menu containing the available multi signature
+ * transaction types. Does not display governance proposal types.
+ */
+export function MultiSignatureCreateAccountProposalView() {
+    const proposals = useSelector(proposalsSelector);
+    const pv = useProtocolVersion(true);
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        return expireProposals(proposals, dispatch);
+    }, [dispatch, proposals]);
+
+    return (
+        <>
+            {accountTransactionTypes.map(toLink(pv))}
+            {pv !== undefined && hasDelegationProtocol(pv) && (
+                <>
+                    {configureBakerLinks(pv)}
+                    {configureDelegationLinks}
+                </>
+            )}
+        </>
+    );
+}
+
+/**
+ * Component that displays a menu containing the available governance
+ * transaction types. 
+*/
+export function MultiSignatureCreateGovernanceProposalView() {
+    const proposals = useSelector(proposalsSelector);
+    const pv = useProtocolVersion(true);
+    const foundationTransactionsEnabled: boolean = useSelector(
+        foundationTransactionsEnabledSelector
+    );
+    const dispatch = useDispatch();
+    
+    useEffect(() => {
+        return expireProposals(proposals, dispatch);
+    }, [dispatch, proposals]);
+    
+    return (
+        <>
+            {foundationTransactionsEnabled &&
+                updateInstructionTypes.map(toLink(pv))}
+        </>
+    );
+}
+
 /**
  * Component that displays a menu containing the available multi signature
  * transaction types. If foundation transactions area enabled in settings,


### PR DESCRIPTION
## Purpose

This PR adds a separate menu for governance transactions in the multi-signature panel.

## Changes

- Remove governance transactions from the `Make new proposal` menu in `Multi signature transactions`.
- Add separate menu `Make new governance proposal` menu for governance transactions in `Multi signature transactions`. The menu is only visible if `Foundation transactions` is enabled in the settings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
