### PR TITLE
Support v2 authorizations (COR-1766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix display of `new size of level 2 key set` which now accounts for removed keys correctly
+- Update the flow for signing authorizations updates with support for v2 authorizations
+
 ## 1.9.0
 
 - Fix crash in `UpdateFoundationAccount` proposal flow

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the repository for the desktop wallet.
+This is the repository for the desktop wallet intended for use alongside the [ledger apps](https://github.com/Concordium/concordium-ledger-app).
 
 ## Dependencies
 

--- a/app/pages/multisig/updates/UpdateGovernanceKeys/UpdateAuthorizationKeys.tsx
+++ b/app/pages/multisig/updates/UpdateGovernanceKeys/UpdateAuthorizationKeys.tsx
@@ -54,7 +54,7 @@ function getKeyUpdateType(protocolVersion: bigint, type: UpdateType) {
         }
         return AuthorizationKeysUpdateType.Level1V0;
     }
-    throw new Error('Invalid key update type.');
+    throw new Error(`Invalid key update type: ${type}`);
 }
 
 interface Props {

--- a/app/pages/multisig/updates/UpdateGovernanceKeys/UpdateAuthorizationKeys.tsx
+++ b/app/pages/multisig/updates/UpdateGovernanceKeys/UpdateAuthorizationKeys.tsx
@@ -36,13 +36,25 @@ import localStyles from './UpdateAuthorizationKeys.module.scss';
 
 function getKeyUpdateType(protocolVersion: bigint, type: UpdateType) {
     if (type === UpdateType.UpdateLevel2KeysUsingRootKeys) {
-        return protocolVersion > 3
-            ? AuthorizationKeysUpdateType.RootV1
-            : AuthorizationKeysUpdateType.RootV0;
+        if (protocolVersion >= 9) {
+            return AuthorizationKeysUpdateType.RootV2;
+        }
+        if (protocolVersion >= 4) {
+            return AuthorizationKeysUpdateType.RootV1;
+        }
+        return AuthorizationKeysUpdateType.RootV0;
     }
-    return protocolVersion > 3
-        ? AuthorizationKeysUpdateType.Level1V1
-        : AuthorizationKeysUpdateType.Level1V0;
+
+    if (type === UpdateType.UpdateLevel2KeysUsingLevel1Keys) {
+        if (protocolVersion >= 9) {
+            return AuthorizationKeysUpdateType.Level1V2;
+        }
+        if (protocolVersion >= 4) {
+            return AuthorizationKeysUpdateType.Level1V1;
+        }
+        return AuthorizationKeysUpdateType.Level1V0;
+    }
+    throw new Error('Invalid key update type.');
 }
 
 interface Props {
@@ -346,7 +358,9 @@ export default function UpdateAuthorizationKeys({
                         </div>
                         <div className="mono">
                             New size of level 2 key set:{' '}
-                            <b>{newLevel2Keys.keys.length}</b>
+                            <b>
+                                {removeRemovedKeys(newLevel2Keys).keys.length}
+                            </b>
                         </div>
                         <ul>
                             {removeRemovedKeys(newLevel2Keys).keys.map(

--- a/app/pages/multisig/updates/UpdateGovernanceKeys/util.ts
+++ b/app/pages/multisig/updates/UpdateGovernanceKeys/util.ts
@@ -1,4 +1,3 @@
-import { isAuthorizationsV1 } from '@concordium/web-sdk';
 import { Authorization, Authorizations } from '../../../../node/NodeApiTypes';
 import {
     AccessStructure,
@@ -61,7 +60,7 @@ export function getCurrentThresholds(
         AccessStructureEnum.addIdentityProvider,
         authorizations.addIdentityProvider.threshold
     );
-    if (isAuthorizationsV1(authorizations)) {
+    if (authorizations.version === 1) {
         currentThresholds.set(
             AccessStructureEnum.cooldownParameters,
             authorizations.cooldownParameters.threshold
@@ -70,6 +69,13 @@ export function getCurrentThresholds(
             AccessStructureEnum.timeParameters,
             authorizations.timeParameters.threshold
         );
+        // `createPlt` is available from protocol version 9.
+        if (authorizations.createPlt) {
+            currentThresholds.set(
+                AccessStructureEnum.createPlt,
+                authorizations.createPlt.threshold
+            );
+        }
     }
     return currentThresholds;
 }
@@ -214,6 +220,8 @@ export function getAccessStructureTitle(
             return 'Cooldown parameters';
         case AccessStructureEnum.timeParameters:
             return 'Time parameters';
+        case AccessStructureEnum.createPlt:
+            return 'Create PLT (protocol level token)';
         default:
             throw new Error(
                 `Unknown access structure type: ${accessStructureType}`
@@ -298,7 +306,7 @@ export function mapCurrentAuthorizationsToUpdate(
         ),
     ];
 
-    if (isAuthorizationsV1(authorizations)) {
+    if (authorizations.version === 1) {
         accessStructures.push(
             mapAuthorizationToAccessStructure(
                 authorizations.cooldownParameters,
@@ -311,6 +319,15 @@ export function mapCurrentAuthorizationsToUpdate(
                 AccessStructureEnum.timeParameters
             )
         );
+        // `createPlt` is available from protocol version 9.
+        if (authorizations.createPlt) {
+            accessStructures.push(
+                mapAuthorizationToAccessStructure(
+                    authorizations.createPlt,
+                    AccessStructureEnum.createPlt
+                )
+            );
+        }
     }
 
     const update: AuthorizationKeysUpdate = {

--- a/app/utils/UpdateSerialization.ts
+++ b/app/utils/UpdateSerialization.ts
@@ -140,10 +140,14 @@ export function convertAuthorizationKeyUpdateType(
             return 1;
         case AuthorizationKeysUpdateType.Level1V1:
             return 2;
+        case AuthorizationKeysUpdateType.Level1V2:
+            return 3;
         case AuthorizationKeysUpdateType.RootV0:
             return 2;
         case AuthorizationKeysUpdateType.RootV1:
             return 3;
+        case AuthorizationKeysUpdateType.RootV2:
+            return 4;
         default:
             throw new Error('Unknown authorization key update type');
     }

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1365,6 +1365,7 @@ export enum AccessStructureEnum {
     addIdentityProvider,
     cooldownParameters,
     timeParameters,
+    createPlt,
 }
 
 export interface AccessStructure {
@@ -1381,8 +1382,10 @@ export interface AccessStructure {
 export enum AuthorizationKeysUpdateType {
     Level1V0, // serialized as 1
     Level1V1, // serialized as 2
+    Level1V2, // serialized as 3
     RootV0, // serialized as 2
     RootV1, // serialized as 3
+    RootV2, // serialized as 4
 }
 
 export function getAuthorizationKeysUpdateVersion(
@@ -1395,6 +1398,9 @@ export function getAuthorizationKeysUpdateVersion(
         case AuthorizationKeysUpdateType.RootV1:
         case AuthorizationKeysUpdateType.Level1V1:
             return 1;
+        case AuthorizationKeysUpdateType.RootV2:
+        case AuthorizationKeysUpdateType.Level1V2:
+            return 2;
         default:
             throw new Error('Unknown authorization key update type');
     }


### PR DESCRIPTION
## Purpose

Related to: https://github.com/Concordium/concordium-ledger-app/pull/116

## Changes

- Fix display of `new size of level 2 key set` which now accounts for removed keys correctly
- Update the flow for signing authorizations updates with support for v2 authorizations
