### PR TITLE
Bugfix: Resolve blank application screen on Ledger connect (CRE-518) and setup issue on Ubuntu v1.7.3 (CRE-52)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,19 +122,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libusb-1.0 libudev-dev rpm wget patchelf build-essential
 
-          # Install libssl1.1 manually on Ubuntu 22.04 and 24.04 if missing
-          if ! dpkg -s libssl1.1 >/dev/null 2>&1; then
-            echo "::group::Installing OpenSSL 1.1 manually"
-            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
-            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
-            sudo dpkg -i libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
-            echo "::endgroup::"
-          fi
+          # Build and install OpenSSL 1.1.1w from source
+          OPENSSL_VERSION=1.1.1w
+          cd /tmp
+          wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-$OPENSSL_VERSION.tar.gz
+          tar -xzf openssl-$OPENSSL_VERSION.tar.gz
+          cd openssl-$OPENSSL_VERSION
+          ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1 shared
+          make -j$(nproc)
+          sudo make install_sw
 
-          # Install OpenSSL development files (static libs)
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev
+          # Configure runtime and build paths
+          echo "/opt/openssl-1.1/lib" | sudo tee /etc/ld.so.conf.d/openssl-1.1.conf
+          sudo ldconfig
+
+          echo "OPENSSL_DIR=/opt/openssl-1.1" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/opt/openssl-1.1/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/opt/openssl-1.1/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       - name: Install Node packages
         env:
@@ -210,7 +214,7 @@ jobs:
 
           # New environment variables for static OpenSSL
           OPENSSL_STATIC: "1"
-          OPENSSL_DIR: "/usr/lib/ssl" 
+          OPENSSL_DIR: "/opt/openssl-1.1"
           PKG_CONFIG_ALLOW_CROSS: "1"
         run: yarn package
 

--- a/app/preload/ledger/ledgerObserverImpl.ts
+++ b/app/preload/ledger/ledgerObserverImpl.ts
@@ -35,10 +35,9 @@ function logError(message: string, ...args: unknown[]) {
     const fullMsg = `[${timestamp}] ERROR: ${message} ${details}\n`;
     try {
         fs.appendFileSync(logPath, fullMsg);
-    } catch (e) {
-        console.error(`[${timestamp}] Failed to write to crash.log`, e);
-    }
-    console.error(fullMsg);
+    // eslint-disable-next-line no-empty
+    } catch (e) {}
+
 }
 
 function isDeviceLockedError(err: unknown): boolean {

--- a/app/preload/ledger/ledgerObserverImpl.ts
+++ b/app/preload/ledger/ledgerObserverImpl.ts
@@ -18,8 +18,6 @@ import { LedgerSubscriptionAction } from '../../components/ledger/useLedger';
 import ledgerIpcCommands from '~/constants/ledgerIpcCommands.json';
 import { LedgerObserver } from './ledgerObserver';
 
-
-
 function isDeviceLockedError(err: unknown): boolean {
     if (!err) return false;
     if (err instanceof Error) {
@@ -40,7 +38,6 @@ let currentTransport: TransportNodeHid | null = null;
  * an empty descriptor (as the descriptor is unused downstream).
  * @returns a promise with a {@link TransportNodeHid}
  */
-
 async function openTransport(): Promise<TransportNodeHid> {
     if (currentTransport) {
         try {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
                 "rpm",
                 "AppImage"
             ],
-            "category": "Development"
+            "category": "Development",
+            "executableArgs": ["--no-sandbox"]
         },
         "mac": {
             "artifactName": "${name}-${version}.${ext}",


### PR DESCRIPTION
## Purpose

Resolving setup issues on Ubuntu and fixing blank screen problems when connecting to a Ledger device with the Governance app opened

## Changes

**Fix CRE-52: Resolve setup issue in Desktop Wallet v1.7.3 on Ubuntu**

- Added "executableArgs": ["--no-sandbox"] to improve compatibility with Ubuntu environments.
- Updated CI/build scripts to build and install OpenSSL 1.1.1w from source, and configured runtime/build paths for OpenSSL. This ensures the wallet works reliably on Ubuntu systems.

**Fix CRE-518: Application screen gets blank when we connect with Ledger**

- Introduced a mutex to ensure only one part of the app can access the Ledger device at a time, reducing crashes and connection conflicts.
- Increased device polling timeout from 2000ms to 5000ms for better stability.
- Enhanced error logging: All device and transport errors are now recorded in crash.log for easier debugging.
- Improved event handling to keep the UI in sync with device state and prevent blank screens.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
