### PR TITLE
Fix: CRE-582 Desktop wallet losses connection after doing single transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## Unreleased
 
-### Changed
+## 1.9.3
 
-- Simplify PLT functionality tests as the functionality is added to the UMD release
+### Fixed
+
+- Fix Desktop wallet losses connection after doing single transaction
 
 ## 1.9.2
+
+### Added
+
+- Simplify PLT functionality tests as the functionality is added to the UMD release
 
 ### Fixed
 

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
     "name": "concordium-desktop-wallet",
     "productName": "concordium-desktop-wallet",
     "description": "concordium-desktop-wallet",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "main": "./main.prod.js",
     "author": {
         "name": "Concordium Software",

--- a/app/preload/ledger/ledgerObserverImpl.ts
+++ b/app/preload/ledger/ledgerObserverImpl.ts
@@ -195,7 +195,6 @@ export default class LedgerObserverImpl implements LedgerObserver {
             try {
                 if (this.concordiumClient) {
                     this.concordiumClient.closeTransport();
-                    this.concordiumClient = undefined;
                 }
             } catch (err) {
                 logger.error(err, 'closeTransport: Error closing concordiumClient transport');


### PR DESCRIPTION
## Purpose

Fix applied where the desktop wallet losses connection after doing a single transaction

## Changes

The transport is closed, and the client is set to undefined in closeTransport(). This can cause the client to become unavailable even if the device is still connected, leading to issues when we try to use the Ledger after a cleanup or disconnect event.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

