### PR TITLE
fix: use macos-15-intel

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -41,7 +41,7 @@ jobs:
             runner: windows-2022
             shell: powershell
           - id: macos-intel
-            runner: macos-14
+            runner: macos-15-intel
             shell: bash
           # currently disabled due to dependency issues
           # - id: macos-arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
             # Since electron-builder does not support pwsh, we use powershell instead.
             shell: powershell
           - id: macos-intel
-            runner: macos-14
+            runner: macos-15-intel
             shell: bash
           # Try enable mac ARM64 build target once node dependencies are updated.
           # - id: macos-arm64


### PR DESCRIPTION
## Purpose
So it seems the macos-14 image is x86 only unless you pay for a larger host (macos-14-large), but macos 15 has an intel image without forcing a larger runner node.

## Changes

changed runner from macos-14 to macos-15-intel

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
